### PR TITLE
Fix: Update cache_lifetime configuration.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
 	github.com/jarcoal/httpmock v1.4.0
-	github.com/quantcdn/quant-admin-go v0.0.0-20250725000746-1905d18bf515
+	github.com/quantcdn/quant-admin-go v0.0.0-20250806224914-726b6fd1d44f
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/quantcdn/quant-admin-go v0.0.0-20250707230838-6138402c98cd h1:ZIYXiBs
 github.com/quantcdn/quant-admin-go v0.0.0-20250707230838-6138402c98cd/go.mod h1:JDPQsgcOJGMBj3RnIbqWGHh9w5qZ+/zqrI3S3de9FWY=
 github.com/quantcdn/quant-admin-go v0.0.0-20250725000746-1905d18bf515 h1:ntp7a4BptLADcsT9JNzUT6Ua1hMY+6XdhzJw4wOVrYg=
 github.com/quantcdn/quant-admin-go v0.0.0-20250725000746-1905d18bf515/go.mod h1:JDPQsgcOJGMBj3RnIbqWGHh9w5qZ+/zqrI3S3de9FWY=
+github.com/quantcdn/quant-admin-go v0.0.0-20250806224914-726b6fd1d44f h1:Y2P+YnOwwX43cDwUclxOV4Qx7L2fgPCfEXVFaUIyfFc=
+github.com/quantcdn/quant-admin-go v0.0.0-20250806224914-726b6fd1d44f/go.mod h1:JDPQsgcOJGMBj3RnIbqWGHh9w5qZ+/zqrI3S3de9FWY=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=

--- a/internal/provider/rule_proxy_resource.go
+++ b/internal/provider/rule_proxy_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"terraform-provider-quant/internal/client"
 	"terraform-provider-quant/internal/resource_rule_proxy"
 	"terraform-provider-quant/internal/utils"
@@ -28,6 +29,35 @@ func NewRuleProxyResource() resource.Resource {
 
 type ruleProxyResource struct {
 	client *client.Client
+}
+
+// Helper functions for backwards compatibility with cache_lifetime field
+// The field is now a string in the schema but the API still expects an integer
+
+// parseCacheLifetime converts a string cache_lifetime value to int64 for API calls
+// Supports backwards compatibility with existing integer configurations
+func parseCacheLifetime(cacheLifetimeStr types.String) (int64, error) {
+	if cacheLifetimeStr.IsNull() || cacheLifetimeStr.IsUnknown() {
+		return 0, fmt.Errorf("cache_lifetime is null or unknown")
+	}
+	
+	value := cacheLifetimeStr.ValueString()
+	if value == "" {
+		return 0, fmt.Errorf("cache_lifetime is empty")
+	}
+	
+	// Parse as integer (handles both string representations of integers and actual integers)
+	cacheLifetime, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid cache_lifetime value '%s': must be a valid integer", value)
+	}
+	
+	return cacheLifetime, nil
+}
+
+// formatCacheLifetime converts a string cache_lifetime value to types.String for Terraform state
+func formatCacheLifetime(cacheLifetime string) types.String {
+	return types.StringValue(cacheLifetime)
 }
 
 func (r *ruleProxyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -278,8 +308,15 @@ func callRuleProxyCreateAPI(ctx context.Context, r *ruleProxyResource, data *res
 	req.SetTo(data.To.ValueString())
 	req.SetHost(data.Host.ValueString())
 	if !data.CacheLifetime.IsNull() {
-		cacheLifetime := data.CacheLifetime.ValueInt64()
-		req.SetCacheLifetime(int32(cacheLifetime))
+		cacheLifetime, err := parseCacheLifetime(data.CacheLifetime)
+		if err != nil {
+			diags.AddError(
+				"Invalid cache_lifetime value",
+				fmt.Sprintf("Could not parse cache_lifetime: %s", err.Error()),
+			)
+			return
+		}
+		req.SetCacheLifetime(strconv.FormatInt(cacheLifetime, 10))
 	}
 
 	if !data.AuthUser.IsNull() && !data.AuthPass.IsNull() {
@@ -544,8 +581,15 @@ func callRuleProxyUpdateAPI(ctx context.Context, r *ruleProxyResource, data *res
 	req.SetTo(data.To.ValueString())
 	req.SetHost(data.Host.ValueString())
 	if !data.CacheLifetime.IsNull() {
-		cacheLifetime := data.CacheLifetime.ValueInt64()
-		req.SetCacheLifetime(int32(cacheLifetime))
+		cacheLifetime, err := parseCacheLifetime(data.CacheLifetime)
+		if err != nil {
+			diags.AddError(
+				"Invalid cache_lifetime value",
+				fmt.Sprintf("Could not parse cache_lifetime: %s", err.Error()),
+			)
+			return
+		}
+		req.SetCacheLifetime(strconv.FormatInt(cacheLifetime, 10))
 	}
 
 	if !data.AuthUser.IsNull() && !data.AuthPass.IsNull() {
@@ -816,9 +860,9 @@ func callRuleProxyReadAPI(ctx context.Context, r *ruleProxyResource, data *resou
 	data.To = types.StringValue(actionConfig.GetTo())
 	data.Host = types.StringValue(actionConfig.GetHost())
 
-	// Handle cache_lifetime - always use the API value
+	// Handle cache_lifetime - always use the API value, convert to string for backwards compatibility
 	if !data.CacheLifetime.IsNull() {
-		data.CacheLifetime = types.Int64Value(int64(actionConfig.GetCacheLifetime()))
+		data.CacheLifetime = formatCacheLifetime(actionConfig.GetCacheLifetime())
 	}
 	// If data.CacheLifetime.IsNull(), leave it null (omitted case)
 

--- a/internal/provider/rule_proxy_resource.go
+++ b/internal/provider/rule_proxy_resource.go
@@ -307,7 +307,7 @@ func callRuleProxyCreateAPI(ctx context.Context, r *ruleProxyResource, data *res
 	// Proxy configuration
 	req.SetTo(data.To.ValueString())
 	req.SetHost(data.Host.ValueString())
-	if !data.CacheLifetime.IsNull() {
+	if !data.CacheLifetime.IsNull() && !data.CacheLifetime.IsUnknown() {
 		cacheLifetime, err := parseCacheLifetime(data.CacheLifetime)
 		if err != nil {
 			diags.AddError(
@@ -580,7 +580,7 @@ func callRuleProxyUpdateAPI(ctx context.Context, r *ruleProxyResource, data *res
 	// Proxy configuration
 	req.SetTo(data.To.ValueString())
 	req.SetHost(data.Host.ValueString())
-	if !data.CacheLifetime.IsNull() {
+	if !data.CacheLifetime.IsNull() && !data.CacheLifetime.IsUnknown() {
 		cacheLifetime, err := parseCacheLifetime(data.CacheLifetime)
 		if err != nil {
 			diags.AddError(

--- a/internal/provider/rule_proxy_resource_test.go
+++ b/internal/provider/rule_proxy_resource_test.go
@@ -41,7 +41,7 @@ var ruleProxyResponse = map[string]interface{}{
 		"host":                         "backend.example.com",
 		"waf_enabled":                  true,
 		"origin_timeout":               "30000",
-		"cache_lifetime":               3600,
+		"cache_lifetime":               "3600",
 		"failover_mode":                false,
 		"failover_origin_ttfb":         "5000",
 		"failover_lifetime":            "300",
@@ -290,6 +290,12 @@ func setupRuleProxyServerForCacheLifetime(t *testing.T, organizationID string, p
 
 	// Create a simple response without WAF complications
 	createSimpleResponse := func(name string, cacheLifetime interface{}) map[string]interface{} {
+		// Convert cache_lifetime to string format for API compatibility
+		var cacheLifetimeStr string
+		if cacheLifetime != nil {
+			cacheLifetimeStr = fmt.Sprintf("%v", cacheLifetime)
+		}
+		
 		return map[string]interface{}{
 			"uuid":             "4bf0b98f-d2f6-49dd-b5f6-5908623a9bc9",
 			"rule_id":          "4bf0b98f-d2f6-49dd-b5f6-5908623a9bc9",
@@ -313,7 +319,7 @@ func setupRuleProxyServerForCacheLifetime(t *testing.T, organizationID string, p
 				"host":                         "backend.example.com",
 				"waf_enabled":                  false,
 				"proxy_alert_enabled":          false,
-				"cache_lifetime":               cacheLifetime,
+				"cache_lifetime":               cacheLifetimeStr,
 				"failover_mode":                false,
 				"failover_origin_ttfb":         "2000",
 				"failover_lifetime":            "300",

--- a/internal/provider/rule_proxy_resource_test.go
+++ b/internal/provider/rule_proxy_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -515,11 +516,11 @@ func TestRuleProxyCacheLifetimeHandling(t *testing.T) {
 			var result string
 
 			// Mock current state (what's in Terraform state)
-			var currentCacheLifetime types.Int64
+			var currentCacheLifetime types.String
 			if tt.configValue == nil {
-				currentCacheLifetime = types.Int64Null()
+				currentCacheLifetime = types.StringNull()
 			} else {
-				currentCacheLifetime = types.Int64Value(*tt.configValue)
+				currentCacheLifetime = types.StringValue(strconv.FormatInt(*tt.configValue, 10))
 			}
 
 			// Apply the logic from our fixed callRuleProxyReadAPI function
@@ -529,7 +530,7 @@ func TestRuleProxyCacheLifetimeHandling(t *testing.T) {
 				} else {
 					result = fmt.Sprintf("%v", tt.apiResponse)
 				}
-			} else if currentCacheLifetime.ValueInt64() == -1 {
+			} else if currentCacheLifetime.ValueString() == "-1" {
 				// Preserve -1 sentinel value
 				result = "-1"
 			} else {

--- a/internal/resource_rule_proxy/rule_proxy_resource_gen.go
+++ b/internal/resource_rule_proxy/rule_proxy_resource_gen.go
@@ -36,7 +36,7 @@ func RuleProxyResourceSchema(ctx context.Context) schema.Schema {
 				Computed: true,
 				Default:  stringdefault.StaticString(""),
 			},
-			"cache_lifetime": schema.Int64Attribute{
+			"cache_lifetime": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
 			},
@@ -396,7 +396,7 @@ type RuleProxyModel struct {
 	Action                    types.String      `tfsdk:"action"`
 	AuthPass                  types.String      `tfsdk:"auth_pass"`
 	AuthUser                  types.String      `tfsdk:"auth_user"`
-	CacheLifetime             types.Int64       `tfsdk:"cache_lifetime"`
+	CacheLifetime             types.String      `tfsdk:"cache_lifetime"`
 	Country                   types.String      `tfsdk:"country"`
 	CountryIs                 types.List        `tfsdk:"country_is"`
 	CountryIsNot              types.List        `tfsdk:"country_is_not"`


### PR DESCRIPTION
- Backend API expects string, previously int was used
- Supports both string and int in TF configurations