### PR TITLE
Feat: Add locks for rules requests.

### DIFF
--- a/internal/client/main.go
+++ b/internal/client/main.go
@@ -1,10 +1,11 @@
 package client
 
 import (
-	"context"
-	"net/http"
+    "context"
+    "net/http"
+    "sync"
 
-	openapi "github.com/quantcdn/quant-admin-go"
+    openapi "github.com/quantcdn/quant-admin-go"
 )
 
 type Client struct {
@@ -14,6 +15,8 @@ type Client struct {
 	Instance        *openapi.APIClient
 	httpClient      *RateLimitedHTTPClient
 	rateLimitConfig *RateLimitConfig
+    // RulesMutex serialises rule modifications across resources that operate on a shared backend file
+    RulesMutex      *sync.Mutex
 }
 
 // ClientOptions allows customization of the client
@@ -75,13 +78,14 @@ func NewWithOptions(bearer string, organization string, opts *ClientOptions) *Cl
 	client := openapi.NewAPIClient(cfg)
 	ctx := context.WithValue(context.Background(), openapi.ContextAccessToken, bearer)
 
-	return &Client{
+    return &Client{
 		Bearer:          bearer,
 		AuthContext:     ctx,
 		Instance:        client,
 		Organization:    organization,
 		httpClient:      httpClient,
 		rateLimitConfig: rateLimitConfig,
+        RulesMutex:      &sync.Mutex{},
 	}
 }
 

--- a/internal/provider/rule_content_filter_resource.go
+++ b/internal/provider/rule_content_filter_resource.go
@@ -54,6 +54,11 @@ func (r *ruleContentFilterResource) Configure(_ context.Context, req resource.Co
 }
 
 func (r *ruleContentFilterResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+    // Serialise rule modifications to avoid backend JSON races
+    if r.client != nil && r.client.RulesMutex != nil {
+        r.client.RulesMutex.Lock()
+        defer r.client.RulesMutex.Unlock()
+    }
 	var data resource_rule_content_filter.RuleContentFilterModel
 
 	// Read Terraform plan data into the model
@@ -100,6 +105,11 @@ func (r *ruleContentFilterResource) Read(ctx context.Context, req resource.ReadR
 }
 
 func (r *ruleContentFilterResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+    // Serialise rule modifications to avoid backend JSON races
+    if r.client != nil && r.client.RulesMutex != nil {
+        r.client.RulesMutex.Lock()
+        defer r.client.RulesMutex.Unlock()
+    }
 	var plan resource_rule_content_filter.RuleContentFilterModel
 
 	// Read Terraform plan data into the model
@@ -136,6 +146,11 @@ func (r *ruleContentFilterResource) Update(ctx context.Context, req resource.Upd
 }
 
 func (r *ruleContentFilterResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+    // Serialise rule modifications to avoid backend JSON races
+    if r.client != nil && r.client.RulesMutex != nil {
+        r.client.RulesMutex.Lock()
+        defer r.client.RulesMutex.Unlock()
+    }
 	var data resource_rule_content_filter.RuleContentFilterModel
 
 	// Read Terraform prior state data into the model

--- a/internal/provider/rule_custom_response_resource.go
+++ b/internal/provider/rule_custom_response_resource.go
@@ -58,6 +58,11 @@ func (r *ruleCustomResponseResource) Configure(_ context.Context, req resource.C
 }
 
 func (r *ruleCustomResponseResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+    // Serialise rule modifications to avoid backend JSON races
+    if r.client != nil && r.client.RulesMutex != nil {
+        r.client.RulesMutex.Lock()
+        defer r.client.RulesMutex.Unlock()
+    }
 	var data resource_rule_custom_response.RuleCustomResponseModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -98,6 +103,11 @@ func (r *ruleCustomResponseResource) Read(ctx context.Context, req resource.Read
 }
 
 func (r *ruleCustomResponseResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+    // Serialise rule modifications to avoid backend JSON races
+    if r.client != nil && r.client.RulesMutex != nil {
+        r.client.RulesMutex.Lock()
+        defer r.client.RulesMutex.Unlock()
+    }
 	var plan resource_rule_custom_response.RuleCustomResponseModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -127,6 +137,11 @@ func (r *ruleCustomResponseResource) Update(ctx context.Context, req resource.Up
 }
 
 func (r *ruleCustomResponseResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+    // Serialise rule modifications to avoid backend JSON races
+    if r.client != nil && r.client.RulesMutex != nil {
+        r.client.RulesMutex.Lock()
+        defer r.client.RulesMutex.Unlock()
+    }
 	var data resource_rule_custom_response.RuleCustomResponseModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)

--- a/internal/provider/rule_proxy_resource.go
+++ b/internal/provider/rule_proxy_resource.go
@@ -86,6 +86,11 @@ func (r *ruleProxyResource) Configure(_ context.Context, req resource.ConfigureR
 }
 
 func (r *ruleProxyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+    // Serialise rule modifications to avoid backend JSON races
+    if r.client != nil && r.client.RulesMutex != nil {
+        r.client.RulesMutex.Lock()
+        defer r.client.RulesMutex.Unlock()
+    }
 	var data resource_rule_proxy.RuleProxyModel
 
 	// Read Terraform plan data into the model
@@ -132,6 +137,11 @@ func (r *ruleProxyResource) Read(ctx context.Context, req resource.ReadRequest, 
 }
 
 func (r *ruleProxyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+    // Serialise rule modifications to avoid backend JSON races
+    if r.client != nil && r.client.RulesMutex != nil {
+        r.client.RulesMutex.Lock()
+        defer r.client.RulesMutex.Unlock()
+    }
 	var plan resource_rule_proxy.RuleProxyModel
 
 	// Read Terraform plan data into the model
@@ -168,6 +178,11 @@ func (r *ruleProxyResource) Update(ctx context.Context, req resource.UpdateReque
 }
 
 func (r *ruleProxyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+    // Serialise rule modifications to avoid backend JSON races
+    if r.client != nil && r.client.RulesMutex != nil {
+        r.client.RulesMutex.Lock()
+        defer r.client.RulesMutex.Unlock()
+    }
 	var data resource_rule_proxy.RuleProxyModel
 
 	// Read Terraform prior state data into the model

--- a/internal/provider/rule_redirect_resource.go
+++ b/internal/provider/rule_redirect_resource.go
@@ -56,6 +56,11 @@ func (r *ruleRedirectResource) Configure(_ context.Context, req resource.Configu
 }
 
 func (r *ruleRedirectResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+    // Serialise rule modifications to avoid backend JSON races
+    if r.client != nil && r.client.RulesMutex != nil {
+        r.client.RulesMutex.Lock()
+        defer r.client.RulesMutex.Unlock()
+    }
 	var data resource_rule_redirect.RuleRedirectModel
 
 	// Read Terraform plan data into the model
@@ -102,6 +107,11 @@ func (r *ruleRedirectResource) Read(ctx context.Context, req resource.ReadReques
 }
 
 func (r *ruleRedirectResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+    // Serialise rule modifications to avoid backend JSON races
+    if r.client != nil && r.client.RulesMutex != nil {
+        r.client.RulesMutex.Lock()
+        defer r.client.RulesMutex.Unlock()
+    }
 	var plan resource_rule_redirect.RuleRedirectModel
 
 	// Read Terraform plan data into the model
@@ -134,6 +144,11 @@ func (r *ruleRedirectResource) Update(ctx context.Context, req resource.UpdateRe
 }
 
 func (r *ruleRedirectResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+    // Serialise rule modifications to avoid backend JSON races
+    if r.client != nil && r.client.RulesMutex != nil {
+        r.client.RulesMutex.Lock()
+        defer r.client.RulesMutex.Unlock()
+    }
 	var data resource_rule_redirect.RuleRedirectModel
 
 	// Read Terraform prior state data into the model


### PR DESCRIPTION
- Implemented provider-level serialisation for all rule_* resources so Terraform can run in parallel, but Create/Update/Delete for rules are executed sequentially.
- Added RulesMutex to internal/client.Client, initialised in NewWithOptions.