### PR TITLE
Fix: Add application plan modifiers.

### DIFF
--- a/internal/resource_rule_proxy/rule_proxy_resource_gen.go
+++ b/internal/resource_rule_proxy/rule_proxy_resource_gen.go
@@ -8,9 +8,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -29,23 +33,38 @@ func RuleProxyResourceSchema(ctx context.Context) schema.Schema {
 			"application_container": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"application_environment": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"application_name": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"application_port": schema.Int64Attribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"application_proxy": schema.BoolAttribute{
 				Optional: true,
 				Computed: true,
 				Default:  booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"auth_pass": schema.StringAttribute{
 				Optional: true,
@@ -121,6 +140,9 @@ func RuleProxyResourceSchema(ctx context.Context) schema.Schema {
 				Computed: true,
 				Validators: []validator.String{
 					HostRequiredUnlessAppProxy(),
+				},
+				PlanModifiers: []planmodifier.String{
+					HostRecomputeWhenAppProxy(),
 				},
 			},
 			"inject_headers": schema.MapAttribute{
@@ -266,6 +288,9 @@ func RuleProxyResourceSchema(ctx context.Context) schema.Schema {
 				Computed: true,
 				Validators: []validator.String{
 					ToRequiredUnlessAppProxy(),
+				},
+				PlanModifiers: []planmodifier.String{
+					ToRecomputeWhenAppProxy(),
 				},
 			},
 			"url": schema.ListAttribute{

--- a/internal/resource_rule_proxy/to_plan_modifier.go
+++ b/internal/resource_rule_proxy/to_plan_modifier.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )

--- a/internal/resource_rule_proxy/to_plan_modifier.go
+++ b/internal/resource_rule_proxy/to_plan_modifier.go
@@ -1,0 +1,71 @@
+package resource_rule_proxy
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// toRecomputeWhenAppProxyPlanModifier ensures `to` is treated as unknown whenever application_proxy is true.
+type toRecomputeWhenAppProxyPlanModifier struct{}
+
+func (m toRecomputeWhenAppProxyPlanModifier) Description(_ context.Context) string {
+	return "Marks 'to' unknown (to be recomputed) when application_proxy is true so backend-computed value is refreshed after save"
+}
+
+func (m toRecomputeWhenAppProxyPlanModifier) MarkdownDescription(_ context.Context) string {
+	return "Marks `to` unknown when `application_proxy` is true so the backend-computed value is refreshed after save"
+}
+
+func (m toRecomputeWhenAppProxyPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// If we're creating and there is no prior state, defer to other modifiers/validators
+	// We only force unknown when application_proxy is explicitly true in the planned config.
+	var appProxy types.Bool
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("application_proxy"), &appProxy)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !appProxy.IsUnknown() && appProxy.ValueBool() {
+		resp.PlanValue = basetypes.NewStringUnknown()
+	}
+}
+
+// hostRecomputeWhenAppProxyPlanModifier ensures `host` is treated as unknown whenever application_proxy is true.
+type hostRecomputeWhenAppProxyPlanModifier struct{}
+
+func (m hostRecomputeWhenAppProxyPlanModifier) Description(_ context.Context) string {
+	return "Marks 'host' unknown (to be recomputed) when application_proxy is true so backend-computed value is refreshed after save"
+}
+
+func (m hostRecomputeWhenAppProxyPlanModifier) MarkdownDescription(_ context.Context) string {
+	return "Marks `host` unknown when `application_proxy` is true so the backend-computed value is refreshed after save"
+}
+
+func (m hostRecomputeWhenAppProxyPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	var appProxy types.Bool
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("application_proxy"), &appProxy)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !appProxy.IsUnknown() && appProxy.ValueBool() {
+		resp.PlanValue = basetypes.NewStringUnknown()
+	}
+}
+
+// ToRecomputeWhenAppProxy returns a plan modifier for the `to` attribute.
+func ToRecomputeWhenAppProxy() planmodifier.String {
+	return toRecomputeWhenAppProxyPlanModifier{}
+}
+
+// HostRecomputeWhenAppProxy returns a plan modifier for the `host` attribute.
+func HostRecomputeWhenAppProxy() planmodifier.String {
+	return hostRecomputeWhenAppProxyPlanModifier{}
+}
+
+


### PR DESCRIPTION
When the planned config has application_proxy = true, we now force to and host to unknown via plan modifiers, so they’re recomputed by the backend on save and refreshed by the post-apply read, regardless of prior state being false or null.