### PR TITLE
chore: bump quant-admin-go to v4.15.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
 	github.com/jarcoal/httpmock v1.4.1
-	github.com/quantcdn/quant-admin-go/v4 v4.15.7
+	github.com/quantcdn/quant-admin-go/v4 v4.15.8
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxu
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/quantcdn/quant-admin-go/v4 v4.15.7 h1:r3CoWuxB710Zv59N9Tw5EwROwEYq+WHRIeKeeJf2EQI=
-github.com/quantcdn/quant-admin-go/v4 v4.15.7/go.mod h1:IHW0nqZIs1meRihtfkKedVrmjl8iuKqVxM9i9lExoAw=
+github.com/quantcdn/quant-admin-go/v4 v4.15.8 h1:YUaTYqmu9xJcZl8jspEZve55X9jmZpPlBUN3pmYxLJA=
+github.com/quantcdn/quant-admin-go/v4 v4.15.8/go.mod h1:IHW0nqZIs1meRihtfkKedVrmjl8iuKqVxM9i9lExoAw=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=


### PR DESCRIPTION
## Summary
- Bumps Go SDK to v4.15.8 (removes duplicate OA annotations, no schema changes)

## Test plan
- [x] `go build ./...` passes locally