### PR TITLE
fix: errcheck lint + bump pulumi go.mod to SDK v4.15.8

### DIFF
--- a/internal/provider/ai_custom_tool_resource.go
+++ b/internal/provider/ai_custom_tool_resource.go
@@ -259,7 +259,7 @@ func callCustomToolReadAPI(ctx context.Context, r *aiCustomToolResource, data *r
 			fmt.Sprintf("Error: %s", err.Error()))
 		return
 	}
-	defer httpResp.Body.Close()
+	defer func() { _ = httpResp.Body.Close() }()
 
 	body, _ := io.ReadAll(httpResp.Body)
 

--- a/pulumi/go.mod
+++ b/pulumi/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.116.0
 	github.com/pulumi/pulumi/sdk/v3 v3.190.0
-	github.com/quantcdn/quant-admin-go/v4 v4.15.7
+	github.com/quantcdn/quant-admin-go/v4 v4.15.8
 	github.com/quantcdn/terraform-provider-quant/v5 v5.0.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/pulumi/go.sum
+++ b/pulumi/go.sum
@@ -757,8 +757,8 @@ github.com/pulumi/terraform-diff-reader v0.0.2 h1:kTE4nEXU3/SYXESvAIem+wyHMI3abq
 github.com/pulumi/terraform-diff-reader v0.0.2/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250923233607-7f1981c8674a h1:bTwou+tt2fyfuuCp9+VQOlgEJk/xKEaYeoX2HCtp2es=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250923233607-7f1981c8674a/go.mod h1:rpW/bFN645nI+o0jth9hyIs/eWi3GP3B1J39fWZKC0Y=
-github.com/quantcdn/quant-admin-go/v4 v4.15.7 h1:r3CoWuxB710Zv59N9Tw5EwROwEYq+WHRIeKeeJf2EQI=
-github.com/quantcdn/quant-admin-go/v4 v4.15.7/go.mod h1:IHW0nqZIs1meRihtfkKedVrmjl8iuKqVxM9i9lExoAw=
+github.com/quantcdn/quant-admin-go/v4 v4.15.8 h1:YUaTYqmu9xJcZl8jspEZve55X9jmZpPlBUN3pmYxLJA=
+github.com/quantcdn/quant-admin-go/v4 v4.15.8/go.mod h1:IHW0nqZIs1meRihtfkKedVrmjl8iuKqVxM9i9lExoAw=
 github.com/rhysd/go-fakeio v1.0.0 h1:+TjiKCOs32dONY7DaoVz/VPOdvRkPfBkEyUDIpM8FQY=
 github.com/rhysd/go-fakeio v1.0.0/go.mod h1:joYxF906trVwp2JLrE4jlN7A0z6wrz8O6o1UjarbFzE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
## Summary
- Fixes errcheck lint warning on `Body.Close()` in ai_custom_tool_resource.go
- Bumps pulumi/go.mod to quant-admin-go v4.15.8 (was missed in #137)

## Test plan
- [x] `go build ./...` passes for both root and pulumi modules