### PR TITLE
fix: pass custom tool inputSchema/outputSchema as JSON strings

### DIFF
--- a/internal/provider/ai_custom_tool_resource.go
+++ b/internal/provider/ai_custom_tool_resource.go
@@ -163,17 +163,23 @@ func getToolName(data *resource_ai_custom_tool.AiCustomToolModel) string {
 func callCustomToolCreateAPI(ctx context.Context, r *aiCustomToolResource, data *resource_ai_custom_tool.AiCustomToolModel) (diags diag.Diagnostics) {
 	org := r.getOrg(data)
 
-	// Build the SDK request. InputSchema is a typed empty object in the TF
-	// schema (no nested attributes) so we pass an empty map — the API accepts
-	// any valid JSON Schema object.
-	// The SDK constructor still expects edgeFunctionUrl but the API now
-	// auto-generates it from edgeFunctionCode. Pass empty string for the
-	// URL and set edgeFunctionCode via AdditionalProperties.
+	// Build the SDK request. InputSchema is a JSON-encoded string in the TF
+	// schema; parse it to a map so the API receives a JSON object.
+	var inputSchema map[string]interface{}
+	if !data.InputSchema.IsNull() && !data.InputSchema.IsUnknown() {
+		if err := json.Unmarshal([]byte(data.InputSchema.ValueString()), &inputSchema); err != nil {
+			diags.AddError("Invalid input_schema JSON", fmt.Sprintf("Failed to parse input_schema: %s", err.Error()))
+			return
+		}
+	} else {
+		inputSchema = map[string]interface{}{"type": "object", "properties": map[string]interface{}{}}
+	}
+
 	sdkReq := quantadmingo.NewCreateCustomToolRequest(
 		data.Name.ValueString(),
 		data.Description.ValueString(),
 		"", // edgeFunctionUrl — computed by API from edgeFunctionCode
-		map[string]interface{}{"type": "object", "properties": map[string]interface{}{}}, // inputSchema default
+		inputSchema,
 	)
 
 	if !data.IsAsync.IsNull() && !data.IsAsync.IsUnknown() {
@@ -198,9 +204,14 @@ func callCustomToolCreateAPI(ctx context.Context, r *aiCustomToolResource, data 
 	if !data.ResponseMode.IsNull() && !data.ResponseMode.IsUnknown() {
 		sdkReq.AdditionalProperties["responseMode"] = data.ResponseMode.ValueString()
 	}
-	// OutputSchema — pass as empty map when known (same as InputSchema).
+	// OutputSchema — parse JSON string to object for the API.
 	if !data.OutputSchema.IsNull() && !data.OutputSchema.IsUnknown() {
-		sdkReq.AdditionalProperties["outputSchema"] = map[string]interface{}{}
+		var outputSchema map[string]interface{}
+		if err := json.Unmarshal([]byte(data.OutputSchema.ValueString()), &outputSchema); err != nil {
+			diags.AddError("Invalid output_schema JSON", fmt.Sprintf("Failed to parse output_schema: %s", err.Error()))
+			return
+		}
+		sdkReq.AdditionalProperties["outputSchema"] = outputSchema
 	}
 
 	sdkResp, httpResp, err := r.client.Instance.AICustomToolsAPI.CreateCustomTool(r.client.AuthContext, org).
@@ -351,28 +362,28 @@ func mapCustomToolFromMap(ctx context.Context, m map[string]interface{}, org str
 	// TimeoutSeconds
 	data.TimeoutSeconds = mapInt64FromAny(m, "timeoutSeconds")
 
-	// InputSchema — empty-attribute custom type; always set to "known".
-	data.InputSchema = resource_ai_custom_tool.InputSchemaValue{}
-	if _, ok := m["inputSchema"]; ok {
-		data.InputSchema = resource_ai_custom_tool.NewInputSchemaValueMust(
-			resource_ai_custom_tool.InputSchemaValue{}.AttributeTypes(ctx),
-			map[string]attr.Value{},
-		)
+	// InputSchema — JSON string from the API response object.
+	if v, ok := m["inputSchema"]; ok && v != nil {
+		schemaJSON, err := json.Marshal(v)
+		if err == nil {
+			data.InputSchema = types.StringValue(string(schemaJSON))
+		} else {
+			data.InputSchema = types.StringNull()
+		}
 	} else {
-		data.InputSchema = resource_ai_custom_tool.NewInputSchemaValueMust(
-			resource_ai_custom_tool.InputSchemaValue{}.AttributeTypes(ctx),
-			map[string]attr.Value{},
-		)
+		data.InputSchema = types.StringNull()
 	}
 
-	// OutputSchema — optional; null if not present.
-	if _, ok := m["outputSchema"]; ok {
-		data.OutputSchema = resource_ai_custom_tool.NewOutputSchemaValueMust(
-			resource_ai_custom_tool.OutputSchemaValue{}.AttributeTypes(ctx),
-			map[string]attr.Value{},
-		)
+	// OutputSchema — JSON string from the API response object, null if absent.
+	if v, ok := m["outputSchema"]; ok && v != nil {
+		schemaJSON, err := json.Marshal(v)
+		if err == nil {
+			data.OutputSchema = types.StringValue(string(schemaJSON))
+		} else {
+			data.OutputSchema = types.StringNull()
+		}
 	} else {
-		data.OutputSchema = resource_ai_custom_tool.NewOutputSchemaValueNull()
+		data.OutputSchema = types.StringNull()
 	}
 
 	data.Organisation = types.StringValue(org)
@@ -393,27 +404,6 @@ func mapCustomToolFromMap(ctx context.Context, m map[string]interface{}, org str
 func buildToolObject(ctx context.Context, m map[string]interface{}, data *resource_ai_custom_tool.AiCustomToolModel) (diags diag.Diagnostics) {
 	toolAttrTypes := resource_ai_custom_tool.ToolValue{}.AttributeTypes(ctx)
 
-	// InputSchema for the nested tool object — basetypes.ObjectValue
-	inputSchemaObj, d := types.ObjectValue(
-		resource_ai_custom_tool.InputSchemaValue{}.AttributeTypes(ctx),
-		map[string]attr.Value{},
-	)
-	diags.Append(d...)
-
-	// OutputSchema for the nested tool object — basetypes.ObjectValue
-	var outputSchemaObj basetypes.ObjectValue
-	if _, ok := m["outputSchema"]; ok {
-		outputSchemaObj, d = types.ObjectValue(
-			resource_ai_custom_tool.OutputSchemaValue{}.AttributeTypes(ctx),
-			map[string]attr.Value{},
-		)
-		diags.Append(d...)
-	} else {
-		outputSchemaObj = types.ObjectNull(
-			resource_ai_custom_tool.OutputSchemaValue{}.AttributeTypes(ctx),
-		)
-	}
-
 	toolAttrs := map[string]attr.Value{
 		"name":                      data.Name,
 		"description":               data.Description,
@@ -423,8 +413,8 @@ func buildToolObject(ctx context.Context, m map[string]interface{}, data *resour
 		"output_schema_description": data.OutputSchemaDescription,
 		"response_mode":             data.ResponseMode,
 		"is_async":                  data.IsAsync,
-		"input_schema":              inputSchemaObj,
-		"output_schema":             outputSchemaObj,
+		"input_schema":              data.InputSchema,
+		"output_schema":             data.OutputSchema,
 		"created_at": func() basetypes.StringValue {
 			if v, ok := m["createdAt"].(string); ok && v != "" {
 				return types.StringValue(v)

--- a/pulumi/provider/cmd/pulumi-resource-quant/schema.json
+++ b/pulumi/provider/cmd/pulumi-resource-quant/schema.json
@@ -308,12 +308,6 @@
                 }
             }
         },
-        "quant:index/AiCustomToolInputSchema:AiCustomToolInputSchema": {
-            "type": "object"
-        },
-        "quant:index/AiCustomToolOutputSchema:AiCustomToolOutputSchema": {
-            "type": "object"
-        },
         "quant:index/AiCustomToolTool:AiCustomToolTool": {
             "properties": {
                 "category": {
@@ -333,7 +327,7 @@
                     "type": "string"
                 },
                 "inputSchema": {
-                    "$ref": "#/types/quant:index/AiCustomToolToolInputSchema:AiCustomToolToolInputSchema"
+                    "type": "string"
                 },
                 "isAsync": {
                     "type": "boolean"
@@ -342,7 +336,7 @@
                     "type": "string"
                 },
                 "outputSchema": {
-                    "$ref": "#/types/quant:index/AiCustomToolToolOutputSchema:AiCustomToolToolOutputSchema"
+                    "type": "string"
                 },
                 "outputSchemaDescription": {
                     "type": "string"
@@ -369,12 +363,6 @@
                     ]
                 }
             }
-        },
-        "quant:index/AiCustomToolToolInputSchema:AiCustomToolToolInputSchema": {
-            "type": "object"
-        },
-        "quant:index/AiCustomToolToolOutputSchema:AiCustomToolToolOutputSchema": {
-            "type": "object"
         },
         "quant:index/AiGovernanceConfig:AiGovernanceConfig": {
             "type": "object"
@@ -3367,8 +3355,8 @@
                     "description": "Computed edge function URL (read-only)"
                 },
                 "inputSchema": {
-                    "$ref": "#/types/quant:index/AiCustomToolInputSchema:AiCustomToolInputSchema",
-                    "description": "JSON Schema defining the tool's input parameters"
+                    "type": "string",
+                    "description": "JSON-encoded JSON Schema object defining the tool's input parameters"
                 },
                 "isAsync": {
                     "type": "boolean",
@@ -3390,8 +3378,8 @@
                     "description": "The organisation ID"
                 },
                 "outputSchema": {
-                    "$ref": "#/types/quant:index/AiCustomToolOutputSchema:AiCustomToolOutputSchema",
-                    "description": "JSON Schema defining the tool's output structure"
+                    "type": "string",
+                    "description": "JSON-encoded JSON Schema object defining the tool's output structure"
                 },
                 "outputSchemaDescription": {
                     "type": "string",
@@ -3449,8 +3437,8 @@
                     "description": "JavaScript source code for the edge function"
                 },
                 "inputSchema": {
-                    "$ref": "#/types/quant:index/AiCustomToolInputSchema:AiCustomToolInputSchema",
-                    "description": "JSON Schema defining the tool's input parameters"
+                    "type": "string",
+                    "description": "JSON-encoded JSON Schema object defining the tool's input parameters"
                 },
                 "isAsync": {
                     "type": "boolean",
@@ -3465,8 +3453,8 @@
                     "description": "The organisation ID"
                 },
                 "outputSchema": {
-                    "$ref": "#/types/quant:index/AiCustomToolOutputSchema:AiCustomToolOutputSchema",
-                    "description": "JSON Schema defining the tool's output structure"
+                    "type": "string",
+                    "description": "JSON-encoded JSON Schema object defining the tool's output structure"
                 },
                 "outputSchemaDescription": {
                     "type": "string",
@@ -3510,8 +3498,8 @@
                         "description": "Computed edge function URL (read-only)"
                     },
                     "inputSchema": {
-                        "$ref": "#/types/quant:index/AiCustomToolInputSchema:AiCustomToolInputSchema",
-                        "description": "JSON Schema defining the tool's input parameters"
+                        "type": "string",
+                        "description": "JSON-encoded JSON Schema object defining the tool's input parameters"
                     },
                     "isAsync": {
                         "type": "boolean",
@@ -3533,8 +3521,8 @@
                         "description": "The organisation ID"
                     },
                     "outputSchema": {
-                        "$ref": "#/types/quant:index/AiCustomToolOutputSchema:AiCustomToolOutputSchema",
-                        "description": "JSON Schema defining the tool's output structure"
+                        "type": "string",
+                        "description": "JSON-encoded JSON Schema object defining the tool's output structure"
                     },
                     "outputSchemaDescription": {
                         "type": "string",

--- a/pulumi/schema/schema.json
+++ b/pulumi/schema/schema.json
@@ -308,12 +308,6 @@
                 }
             }
         },
-        "quant:index/AiCustomToolInputSchema:AiCustomToolInputSchema": {
-            "type": "object"
-        },
-        "quant:index/AiCustomToolOutputSchema:AiCustomToolOutputSchema": {
-            "type": "object"
-        },
         "quant:index/AiCustomToolTool:AiCustomToolTool": {
             "properties": {
                 "category": {
@@ -333,7 +327,7 @@
                     "type": "string"
                 },
                 "inputSchema": {
-                    "$ref": "#/types/quant:index/AiCustomToolToolInputSchema:AiCustomToolToolInputSchema"
+                    "type": "string"
                 },
                 "isAsync": {
                     "type": "boolean"
@@ -342,7 +336,7 @@
                     "type": "string"
                 },
                 "outputSchema": {
-                    "$ref": "#/types/quant:index/AiCustomToolToolOutputSchema:AiCustomToolToolOutputSchema"
+                    "type": "string"
                 },
                 "outputSchemaDescription": {
                     "type": "string"
@@ -369,12 +363,6 @@
                     ]
                 }
             }
-        },
-        "quant:index/AiCustomToolToolInputSchema:AiCustomToolToolInputSchema": {
-            "type": "object"
-        },
-        "quant:index/AiCustomToolToolOutputSchema:AiCustomToolToolOutputSchema": {
-            "type": "object"
         },
         "quant:index/AiGovernanceConfig:AiGovernanceConfig": {
             "type": "object"
@@ -3367,8 +3355,8 @@
                     "description": "Computed edge function URL (read-only)"
                 },
                 "inputSchema": {
-                    "$ref": "#/types/quant:index/AiCustomToolInputSchema:AiCustomToolInputSchema",
-                    "description": "JSON Schema defining the tool's input parameters"
+                    "type": "string",
+                    "description": "JSON-encoded JSON Schema object defining the tool's input parameters"
                 },
                 "isAsync": {
                     "type": "boolean",
@@ -3390,8 +3378,8 @@
                     "description": "The organisation ID"
                 },
                 "outputSchema": {
-                    "$ref": "#/types/quant:index/AiCustomToolOutputSchema:AiCustomToolOutputSchema",
-                    "description": "JSON Schema defining the tool's output structure"
+                    "type": "string",
+                    "description": "JSON-encoded JSON Schema object defining the tool's output structure"
                 },
                 "outputSchemaDescription": {
                     "type": "string",
@@ -3449,8 +3437,8 @@
                     "description": "JavaScript source code for the edge function"
                 },
                 "inputSchema": {
-                    "$ref": "#/types/quant:index/AiCustomToolInputSchema:AiCustomToolInputSchema",
-                    "description": "JSON Schema defining the tool's input parameters"
+                    "type": "string",
+                    "description": "JSON-encoded JSON Schema object defining the tool's input parameters"
                 },
                 "isAsync": {
                     "type": "boolean",
@@ -3465,8 +3453,8 @@
                     "description": "The organisation ID"
                 },
                 "outputSchema": {
-                    "$ref": "#/types/quant:index/AiCustomToolOutputSchema:AiCustomToolOutputSchema",
-                    "description": "JSON Schema defining the tool's output structure"
+                    "type": "string",
+                    "description": "JSON-encoded JSON Schema object defining the tool's output structure"
                 },
                 "outputSchemaDescription": {
                     "type": "string",
@@ -3510,8 +3498,8 @@
                         "description": "Computed edge function URL (read-only)"
                     },
                     "inputSchema": {
-                        "$ref": "#/types/quant:index/AiCustomToolInputSchema:AiCustomToolInputSchema",
-                        "description": "JSON Schema defining the tool's input parameters"
+                        "type": "string",
+                        "description": "JSON-encoded JSON Schema object defining the tool's input parameters"
                     },
                     "isAsync": {
                         "type": "boolean",
@@ -3533,8 +3521,8 @@
                         "description": "The organisation ID"
                     },
                     "outputSchema": {
-                        "$ref": "#/types/quant:index/AiCustomToolOutputSchema:AiCustomToolOutputSchema",
-                        "description": "JSON Schema defining the tool's output structure"
+                        "type": "string",
+                        "description": "JSON-encoded JSON Schema object defining the tool's output structure"
                     },
                     "outputSchemaDescription": {
                         "type": "string",


### PR DESCRIPTION
## Summary
The generated schema now uses `StringAttribute` for `inputSchema` and `outputSchema` (from portal OA spec change `object` → `string` in v4.17.0). The CRUD code parses JSON strings from config into objects for the API, and marshals API response objects back to JSON strings for state.

Previously these were `SingleNestedAttribute` with empty custom types that silently dropped all schema data, causing the API to receive `{type: "object", properties: {}}` on every update.

## Related
- Portal: `11e1cd63` on `develop` (OA spec change)
- Generated PR: #141 (schema type change, merged)
- Lambda: register-tool response now includes schemas

## Test plan
- [x] `TF_ACC=1 go test ./internal/provider/` — all pass
- [x] `golangci-lint run` — 0 issues
- [x] Pulumi provider tests pass
- [x] Manually verified: Pulumi `up` → API has correct schemas → `preview` shows schema fields