### PR TITLE
fix: add UseStateForUnknown to governance + custom tool, fix timeout mapping

### DIFF
--- a/internal/provider/ai_custom_tool_resource.go
+++ b/internal/provider/ai_custom_tool_resource.go
@@ -36,7 +36,11 @@ func (r *aiCustomToolResource) Metadata(_ context.Context, req resource.Metadata
 }
 
 func (r *aiCustomToolResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = resource_ai_custom_tool.AiCustomToolResourceSchema(ctx)
+	s := resource_ai_custom_tool.AiCustomToolResourceSchema(ctx)
+	addUseStateForUnknown(s.Attributes)
+	// These change on every create/update — must not carry state forward.
+	clearPlanModifiers(s.Attributes, "success", "is_update", "message")
+	resp.Schema = s
 }
 
 func (r *aiCustomToolResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -359,8 +363,19 @@ func mapCustomToolFromMap(ctx context.Context, m map[string]interface{}, org str
 	// IsAsync
 	data.IsAsync = mapBoolFromAny(m, "isAsync")
 
-	// TimeoutSeconds
-	data.TimeoutSeconds = mapInt64FromAny(m, "timeoutSeconds")
+	// TimeoutSeconds — API returns "timeout" in milliseconds, TF uses seconds.
+	if v, ok := m["timeout"]; ok {
+		switch t := v.(type) {
+		case float64:
+			data.TimeoutSeconds = types.Int64Value(int64(t) / 1000)
+		case int64:
+			data.TimeoutSeconds = types.Int64Value(t / 1000)
+		default:
+			data.TimeoutSeconds = types.Int64Null()
+		}
+	} else {
+		data.TimeoutSeconds = types.Int64Null()
+	}
 
 	// InputSchema — JSON string from the API response object.
 	if v, ok := m["inputSchema"]; ok && v != nil {

--- a/internal/provider/ai_governance_resource.go
+++ b/internal/provider/ai_governance_resource.go
@@ -35,7 +35,11 @@ func (r *aiGovernanceResource) Metadata(_ context.Context, req resource.Metadata
 }
 
 func (r *aiGovernanceResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = resource_ai_governance.AiGovernanceResourceSchema(ctx)
+	s := resource_ai_governance.AiGovernanceResourceSchema(ctx)
+	addUseStateForUnknown(s.Attributes)
+	// version and success change on every update — must not carry state forward.
+	clearPlanModifiers(s.Attributes, "version", "success")
+	resp.Schema = s
 }
 
 func (r *aiGovernanceResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/rule_helpers.go
+++ b/internal/provider/rule_helpers.go
@@ -235,6 +235,30 @@ func clearStringPlanModifiers(attrs map[string]schema.Attribute, names ...string
 	}
 }
 
+// clearPlanModifiers strips plan modifiers from named attributes of any type.
+func clearPlanModifiers(attrs map[string]schema.Attribute, names ...string) {
+	for _, name := range names {
+		attr, ok := attrs[name]
+		if !ok {
+			continue
+		}
+		switch a := attr.(type) {
+		case schema.StringAttribute:
+			a.PlanModifiers = nil
+			attrs[name] = a
+		case schema.Int64Attribute:
+			a.PlanModifiers = nil
+			attrs[name] = a
+		case schema.BoolAttribute:
+			a.PlanModifiers = nil
+			attrs[name] = a
+		case schema.Float64Attribute:
+			a.PlanModifiers = nil
+			attrs[name] = a
+		}
+	}
+}
+
 // buildConditionalListsForRequest is a convenience wrapper that applies
 // buildConditionalList for all three standard conditional triplets (country,
 // ip, method) in one call.


### PR DESCRIPTION
Reduces perpetual plan diffs by adding UseStateForUnknown to computed fields and fixing the timeout seconds mapping from API milliseconds.