### PR TITLE
fix: allow empty guardrailPreset to clear guardrails

### DIFF
--- a/internal/provider/ai_agent_overlay_resource.go
+++ b/internal/provider/ai_agent_overlay_resource.go
@@ -38,7 +38,9 @@ func (r *aiAgentOverlayResource) Metadata(_ context.Context, req resource.Metada
 }
 
 func (r *aiAgentOverlayResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = resource_ai_agent_overlay.AiAgentOverlayResourceSchema(ctx)
+	s := resource_ai_agent_overlay.AiAgentOverlayResourceSchema(ctx)
+	clearValidators(s.Attributes, "guardrail_preset")
+	resp.Schema = s
 }
 
 func (r *aiAgentOverlayResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/ai_agent_resource.go
+++ b/internal/provider/ai_agent_resource.go
@@ -38,7 +38,11 @@ func (r *aiAgentResource) Metadata(_ context.Context, req resource.MetadataReque
 }
 
 func (r *aiAgentResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = resource_ai_agent.AiAgentResourceSchema(ctx)
+	s := resource_ai_agent.AiAgentResourceSchema(ctx)
+	// Allow guardrail_preset to be empty (clear guardrails). The generated
+	// schema has a OneOf validator that only accepts the three presets.
+	clearValidators(s.Attributes, "guardrail_preset")
+	resp.Schema = s
 }
 
 func (r *aiAgentResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/rule_helpers.go
+++ b/internal/provider/rule_helpers.go
@@ -259,6 +259,20 @@ func clearPlanModifiers(attrs map[string]schema.Attribute, names ...string) {
 	}
 }
 
+// clearValidators removes all validators from the named string attributes.
+// Use this to relax generated OneOf validators that don't allow empty/null
+// values (e.g. guardrail_preset needs to accept "" to clear guardrails).
+func clearValidators(attrs map[string]schema.Attribute, names ...string) {
+	for _, name := range names {
+		if attr, ok := attrs[name]; ok {
+			if sa, ok := attr.(schema.StringAttribute); ok {
+				sa.Validators = nil
+				attrs[name] = sa
+			}
+		}
+	}
+}
+
 // buildConditionalListsForRequest is a convenience wrapper that applies
 // buildConditionalList for all three standard conditional triplets (country,
 // ip, method) in one call.

--- a/internal/provider/slack_bot_resource.go
+++ b/internal/provider/slack_bot_resource.go
@@ -39,7 +39,9 @@ func (r *slackBotResource) Metadata(_ context.Context, req resource.MetadataRequ
 }
 
 func (r *slackBotResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = resource_slack_bot.SlackBotResourceSchema(ctx)
+	s := resource_slack_bot.SlackBotResourceSchema(ctx)
+	clearValidators(s.Attributes, "guardrail_preset")
+	resp.Schema = s
 }
 
 func (r *slackBotResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {


### PR DESCRIPTION
Strip OneOf validator from guardrail_preset so empty string can be sent to clear guardrails. Affects agent, overlay, and slack bot resources.