### PR TITLE
feat(crawler-schedule): add ImportState support

### DIFF
--- a/internal/provider/crawler_schedule_resource.go
+++ b/internal/provider/crawler_schedule_resource.go
@@ -134,7 +134,7 @@ func (r *crawlerScheduleResource) ImportState(ctx context.Context, req resource.
 	parts := strings.Split(req.ID, ":")
 	if len(parts) != 3 {
 		resp.Diagnostics.AddError("Invalid Import ID",
-			"Import ID should be in the format 'project:crawler_uuid:schedule_id'")
+			"Import ID should be in the format `project:crawler_uuid:schedule_id`")
 		return
 	}
 
@@ -196,6 +196,11 @@ func callCrawlerScheduleReadAPI(ctx context.Context, r *crawlerScheduleResource,
 	if schedule.Project.IsNull() || schedule.Project.IsUnknown() {
 		diags.AddAttributeError(path.Root("project"), "Missing schedule.project attribute",
 			"To read schedule information, project must be provided.")
+		return
+	}
+	if schedule.Crawler.IsNull() || schedule.Crawler.IsUnknown() {
+		diags.AddAttributeError(path.Root("crawler"), "Missing schedule.crawler attribute",
+			"To read schedule information, crawler must be provided.")
 		return
 	}
 

--- a/internal/provider/crawler_schedule_resource.go
+++ b/internal/provider/crawler_schedule_resource.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
+
 	"github.com/quantcdn/terraform-provider-quant/v5/internal/client"
 	"github.com/quantcdn/terraform-provider-quant/v5/internal/mapper"
 	"github.com/quantcdn/terraform-provider-quant/v5/internal/resource_crawler_schedule"
@@ -17,8 +19,9 @@ import (
 )
 
 var (
-	_ resource.Resource              = (*crawlerScheduleResource)(nil)
-	_ resource.ResourceWithConfigure = (*crawlerScheduleResource)(nil)
+	_ resource.Resource                = (*crawlerScheduleResource)(nil)
+	_ resource.ResourceWithConfigure   = (*crawlerScheduleResource)(nil)
+	_ resource.ResourceWithImportState = (*crawlerScheduleResource)(nil)
 )
 
 func NewCrawlerScheduleResource() resource.Resource {
@@ -122,6 +125,38 @@ func (r *crawlerScheduleResource) Delete(ctx context.Context, req resource.Delet
 	}
 
 	resp.Diagnostics.Append(callCrawlerScheduleDeleteAPI(ctx, r, &data)...)
+}
+
+// ---------------------------------------------------------------------------
+// ImportState
+// ---------------------------------------------------------------------------
+func (r *crawlerScheduleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.Split(req.ID, ":")
+	if len(parts) != 3 {
+		resp.Diagnostics.AddError("Invalid Import ID",
+			"Import ID should be in the format 'project:crawler_uuid:schedule_id'")
+		return
+	}
+
+	scheduleId, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Import ID",
+			fmt.Sprintf("Schedule id must be an integer, got %q: %s", parts[2], err.Error()))
+		return
+	}
+
+	var data resource_crawler_schedule.CrawlerScheduleModel
+	data.Project = types.StringValue(parts[0])
+	data.Crawler = types.StringValue(parts[1])
+	data.Id = types.Int64Value(scheduleId)
+
+	diags := callCrawlerScheduleReadAPI(ctx, r, &data)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/provider/crawler_schedule_resource_test.go
+++ b/internal/provider/crawler_schedule_resource_test.go
@@ -135,11 +135,10 @@ func TestAccCrawlerScheduleResource_basic(t *testing.T) {
 			},
 			// Step 2: Import
 			{
-				ResourceName:            "quant_crawler_schedule.test",
-				ImportState:             true,
-				ImportStateId:           "test-project:test-crawler-uuid:1",
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"crawler"},
+				ResourceName:      "quant_crawler_schedule.test",
+				ImportState:       true,
+				ImportStateId:     "test-project:test-crawler-uuid:1",
+				ImportStateVerify: true,
 			},
 			// Step 3: Update
 			{
@@ -152,6 +151,46 @@ func TestAccCrawlerScheduleResource_basic(t *testing.T) {
 				),
 			},
 			// Step 4: Delete (implicit)
+		},
+	})
+}
+
+func TestAccCrawlerScheduleResource_ImportError(t *testing.T) {
+	setupCrawlerScheduleServer(t, "test-org", "test-project")
+	defer httpmock.DeactivateAndReset()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() {},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create a resource so a state entry exists to import against.
+			{
+				Config: testAccCrawlerScheduleResourceConfig("test-org", "test-project", "test-schedule", "0 0 * * *"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCrawlerScheduleExists("quant_crawler_schedule.test"),
+				),
+			},
+			// Step 2: Too few parts (2).
+			{
+				ResourceName:  "quant_crawler_schedule.test",
+				ImportState:   true,
+				ImportStateId: "test-project:test-crawler-uuid",
+				ExpectError:   regexp.MustCompile("Invalid Import ID"),
+			},
+			// Step 3: Too many parts (4).
+			{
+				ResourceName:  "quant_crawler_schedule.test",
+				ImportState:   true,
+				ImportStateId: "a:b:c:d",
+				ExpectError:   regexp.MustCompile("Invalid Import ID"),
+			},
+			// Step 4: Non-integer schedule id.
+			{
+				ResourceName:  "quant_crawler_schedule.test",
+				ImportState:   true,
+				ImportStateId: "test-project:test-crawler-uuid:notanumber",
+				ExpectError:   regexp.MustCompile("Invalid Import ID"),
+			},
 		},
 	})
 }

--- a/internal/provider/crawler_schedule_resource_test.go
+++ b/internal/provider/crawler_schedule_resource_test.go
@@ -28,14 +28,14 @@ func setupCrawlerScheduleServer(t *testing.T, organizationID string, projectID s
 		return map[string]interface{}{
 			"id":                   1,
 			"name":                 currentName,
-			"project_id":          17,
+			"project_id":           17,
 			"schedule_cron_string": currentCron,
-			"crawler_schedule":    currentCron,
-			"crawler_uuid":        crawlerUUID,
-			"crawler_config_id":   5,
-			"crawler_last_run_id": 0,
-			"created_at":          "2024-06-28T03:33:02.000000Z",
-			"updated_at":          "2024-06-28T03:50:26.000000Z",
+			"crawler_schedule":     currentCron,
+			"crawler_uuid":         crawlerUUID,
+			"crawler_config_id":    5,
+			"crawler_last_run_id":  0,
+			"created_at":           "2024-06-28T03:33:02.000000Z",
+			"updated_at":           "2024-06-28T03:50:26.000000Z",
 		}
 	}
 
@@ -133,7 +133,15 @@ func TestAccCrawlerScheduleResource_basic(t *testing.T) {
 					testAccCheckCrawlerScheduleExists("quant_crawler_schedule.test"),
 				),
 			},
-			// Step 2: Update
+			// Step 2: Import
+			{
+				ResourceName:            "quant_crawler_schedule.test",
+				ImportState:             true,
+				ImportStateId:           "test-project:test-crawler-uuid:1",
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"crawler"},
+			},
+			// Step 3: Update
 			{
 				Config: testAccCrawlerScheduleResourceConfig("test-org", "test-project", "updated-schedule", "0 12 * * *"),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -143,7 +151,7 @@ func TestAccCrawlerScheduleResource_basic(t *testing.T) {
 					testAccCheckCrawlerScheduleExists("quant_crawler_schedule.test"),
 				),
 			},
-			// Step 3: Delete (implicit)
+			// Step 4: Delete (implicit)
 		},
 	})
 }


### PR DESCRIPTION
## Summary

`quant_crawler_schedule` was the only resource without an `ImportState`
implementation, so `terraform import` — and `pulumi import` via the bridge —
failed with **"Resource Import Not Implemented"**. This adds import support.

## Change

- Implement `ImportState` on `crawlerScheduleResource` and assert
  `resource.ResourceWithImportState`.
- Import ID format: **`project:crawler_uuid:schedule_id`**. All three are required
  because the read API (`CrawlerSchedulesShow`) needs org (from the client) +
  project + crawler UUID + schedule id. This mirrors the sibling `quant_crawler`
  resource (`project:uuid`) with the schedule id appended.
- Parsing validates the 3-part arity and that the schedule id is an integer, then
  delegates to the existing `callCrawlerScheduleReadAPI` to hydrate state.
- Added an import step to the existing httpmock-based acceptance test
  (`TestAccCrawlerScheduleResource_basic`), matching the pattern used by the
  crawler resource test.

## Verification

- `go build ./...`, `go vet ./internal/provider/`, `gofmt -l` — all clean.
- **End-to-end against the live API** (built the provider, used `dev_overrides`):
  `terraform import quant_crawler_schedule.test "<project>:<crawler_uuid>:<id>"`
  succeeded, and a subsequent `terraform plan` reported **"No changes"** when the
  cron matched the live value.

## Pulumi impact

No Pulumi-side code change is required. `ImportState` is runtime behavior (not
schema), so the bridge schema is unchanged. Cutting a new `v5.x.0` release rebuilds
`pulumi-resource-quant` and republishes `@quantcdn/pulumi-quant` via `release.yml`,
at which point `pulumi import` of crawler schedules works automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
