### PR TITLE
test(pulumi): cover v4.19.0 governance maps + redirect_host

### DIFF
--- a/pulumi/e2e/programs/ai/Pulumi.yaml
+++ b/pulumi/e2e/programs/ai/Pulumi.yaml
@@ -23,6 +23,15 @@ resources:
       modelLists:
         - anthropic.claude-3-5-sonnet-20241022-v2:0
         - anthropic.claude-3-haiku-20240307-v1:0
+      spendLimits:
+        monthlyBudgetCents: 1000000
+        interfaceLimits:
+          slack:
+            dailyCents: 5000
+            monthlyCents: 100000
+        userOverrides:
+          "system:code-agent":
+            unlimited: true
   testSkill:
     type: quant:index:AiSkill
     properties:

--- a/pulumi/provider/provider_test.go
+++ b/pulumi/provider/provider_test.go
@@ -352,6 +352,65 @@ resources:
 `)
 }
 
+// Exercises the v4.19.0 governance spend-limit maps end-to-end through the
+// Pulumi schema + bridge: interface_limits (per-interface caps) and
+// user_overrides (named per-user caps incl. unlimited).
+func TestPreview_AiGovernanceSpendLimits(t *testing.T) {
+	previewProgram(t, "test-ai-governance", `
+name: test-ai-governance
+runtime: yaml
+resources:
+  testGov:
+    type: quant:index:AiGovernance
+    properties:
+      organisation: preview-test-org
+      aiEnabled: true
+      modelPolicy: blocklist
+      spendLimits:
+        monthlyBudgetCents: 1000000
+        interfaceLimits:
+          slack:
+            dailyCents: 5000
+            monthlyCents: 100000
+          autonomous:
+            monthlyCents: 250000
+        userOverrides:
+          "1234":
+            dailyCents: 20000
+            monthlyCents: 400000
+          "5678":
+            unlimited: true
+`)
+}
+
+// Exercises the v4.19.0 origin_protection_config.redirect_host on an application
+// container through the Pulumi schema + bridge.
+func TestPreview_ApplicationOriginProtectionRedirect(t *testing.T) {
+	previewProgram(t, "test-app-origin-redirect", `
+name: test-app-origin-redirect
+runtime: yaml
+resources:
+  testApp:
+    type: quant:index:Application
+    properties:
+      appName: preview-test-app-opc
+      application: preview-test-app-opc
+      composeDefinition:
+        containers:
+          - name: web
+            imageReference:
+              type: external
+              identifier: nginx:latest
+            cpu: 256
+            memory: 512
+            originProtectionConfig:
+              enabled: true
+              redirectHost: www.example.com
+              ipAllows:
+                - 10.0.0.0/8
+`)
+}
+
 func TestPreview_Volume(t *testing.T) {
 	previewProgram(t, "test-volume", `
 name: test-volume


### PR DESCRIPTION
Adds Pulumi-level test coverage for the v4.19.0 fields shipped in #152 / v5.11.0.

## Mock preview tests (no API — run by `make test` + CI)
- `TestPreview_AiGovernanceSpendLimits` — `AiGovernance` with `spendLimits.interfaceLimits` (per-interface caps) + `userOverrides` (named per-user caps incl. `unlimited`).
- `TestPreview_ApplicationOriginProtectionRedirect` — application container `originProtectionConfig.redirectHost`.

Both run `pulumi preview` against the built provider and assert the schema + bridge accept and plan the new fields. Verified passing locally (full provider suite green).

## E2E (real round-trip — `make test-e2e`, needs `QUANTCDN_API_TOKEN` + a throwaway `QUANTCDN_ORGANIZATION`)
- `e2e/programs/ai/Pulumi.yaml`: added `spendLimits.interfaceLimits`/`userOverrides` to the existing `testGovernance` resource so the real `pulumi up`/`destroy` exercises them.