### PR TITLE
feat(governance): per-token spend limit mappings + v4.20.0 SDK bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
 	github.com/jarcoal/httpmock v1.4.1
-	github.com/quantcdn/quant-admin-go/v4 v4.19.0
+	github.com/quantcdn/quant-admin-go/v4 v4.20.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxu
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/quantcdn/quant-admin-go/v4 v4.19.0 h1:KShkFOCb7zMHBWzHtetroGkJ+RLfEHK1NJJkex64NRI=
-github.com/quantcdn/quant-admin-go/v4 v4.19.0/go.mod h1:IHW0nqZIs1meRihtfkKedVrmjl8iuKqVxM9i9lExoAw=
+github.com/quantcdn/quant-admin-go/v4 v4.20.0 h1:oNdXojSVm1jvAwvTB5fcnoBbCU+JRVtdlvsw0Vl0HZI=
+github.com/quantcdn/quant-admin-go/v4 v4.20.0/go.mod h1:IHW0nqZIs1meRihtfkKedVrmjl8iuKqVxM9i9lExoAw=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=

--- a/internal/provider/ai_governance_resource.go
+++ b/internal/provider/ai_governance_resource.go
@@ -226,6 +226,12 @@ func callGovernancePutAPI(ctx context.Context, r *aiGovernanceResource, data *re
 		if !sl.PerUserDailyBudgetCents.IsNull() && !sl.PerUserDailyBudgetCents.IsUnknown() {
 			sdkSL.SetPerUserDailyBudgetCents(int32(sl.PerUserDailyBudgetCents.ValueInt64()))
 		}
+		if !sl.PerTokenMonthlyBudgetCents.IsNull() && !sl.PerTokenMonthlyBudgetCents.IsUnknown() {
+			sdkSL.SetPerTokenMonthlyBudgetCents(int32(sl.PerTokenMonthlyBudgetCents.ValueInt64()))
+		}
+		if !sl.PerTokenDailyBudgetCents.IsNull() && !sl.PerTokenDailyBudgetCents.IsUnknown() {
+			sdkSL.SetPerTokenDailyBudgetCents(int32(sl.PerTokenDailyBudgetCents.ValueInt64()))
+		}
 		if !sl.WarningThresholdPercent.IsNull() && !sl.WarningThresholdPercent.IsUnknown() {
 			sdkSL.SetWarningThresholdPercent(int32(sl.WarningThresholdPercent.ValueInt64()))
 		}
@@ -238,6 +244,11 @@ func callGovernancePutAPI(ctx context.Context, r *aiGovernanceResource, data *re
 			uoSDK, d := userOverridesToSDK(ctx, sl.UserOverrides)
 			diags.Append(d...)
 			sdkSL.SetUserOverrides(uoSDK)
+		}
+		if !sl.TokenOverrides.IsNull() && !sl.TokenOverrides.IsUnknown() {
+			toSDK, d := tokenOverridesToSDK(ctx, sl.TokenOverrides)
+			diags.Append(d...)
+			sdkSL.SetTokenOverrides(toSDK)
 		}
 		sdkReq.SetSpendLimits(*sdkSL)
 	}
@@ -344,15 +355,20 @@ func mapGovernanceGetResponse(ctx context.Context, resp *quantadmingo.GetGoverna
 		diags.Append(ild...)
 		uoTF, uod := userOverridesToTF(ctx, slPtr.GetUserOverrides())
 		diags.Append(uod...)
+		toTF, tod := tokenOverridesToTF(ctx, slPtr.GetTokenOverrides())
+		diags.Append(tod...)
 		slAttrTypes := resource_ai_governance.SpendLimitsValue{}.AttributeTypes(ctx)
 		slAttrs := map[string]attr.Value{
-			"monthly_budget_cents":          nullableInt32ToInt64(slPtr.MonthlyBudgetCents),
-			"daily_budget_cents":            nullableInt32ToInt64(slPtr.DailyBudgetCents),
-			"per_user_monthly_budget_cents": nullableInt32ToInt64(slPtr.PerUserMonthlyBudgetCents),
-			"per_user_daily_budget_cents":   nullableInt32ToInt64(slPtr.PerUserDailyBudgetCents),
-			"warning_threshold_percent":     nullableInt32ToInt64(slPtr.WarningThresholdPercent),
-			"interface_limits":              ilTF,
-			"user_overrides":                uoTF,
+			"monthly_budget_cents":           nullableInt32ToInt64(slPtr.MonthlyBudgetCents),
+			"daily_budget_cents":             nullableInt32ToInt64(slPtr.DailyBudgetCents),
+			"per_user_monthly_budget_cents":  nullableInt32ToInt64(slPtr.PerUserMonthlyBudgetCents),
+			"per_user_daily_budget_cents":    nullableInt32ToInt64(slPtr.PerUserDailyBudgetCents),
+			"per_token_monthly_budget_cents": nullableInt32ToInt64(slPtr.PerTokenMonthlyBudgetCents),
+			"per_token_daily_budget_cents":   nullableInt32ToInt64(slPtr.PerTokenDailyBudgetCents),
+			"warning_threshold_percent":      nullableInt32ToInt64(slPtr.WarningThresholdPercent),
+			"interface_limits":               ilTF,
+			"user_overrides":                 uoTF,
+			"token_overrides":                toTF,
 		}
 		slVal, d := resource_ai_governance.NewSpendLimitsValue(slAttrTypes, slAttrs)
 		diags.Append(d...)
@@ -449,15 +465,20 @@ func mapGovernanceConfigFromMap(ctx context.Context, configMap map[string]interf
 			diags.Append(ild...)
 			uoTF, uod := userOverridesFromRawMap(ctx, slMap["userOverrides"])
 			diags.Append(uod...)
+			toTF, tod := tokenOverridesFromRawMap(ctx, slMap["tokenOverrides"])
+			diags.Append(tod...)
 			slAttrTypes := resource_ai_governance.SpendLimitsValue{}.AttributeTypes(ctx)
 			slAttrs := map[string]attr.Value{
-				"monthly_budget_cents":          optionalInt64FromMap(slMap, "monthlyBudgetCents"),
-				"daily_budget_cents":            optionalInt64FromMap(slMap, "dailyBudgetCents"),
-				"per_user_monthly_budget_cents": optionalInt64FromMap(slMap, "perUserMonthlyBudgetCents"),
-				"per_user_daily_budget_cents":   optionalInt64FromMap(slMap, "perUserDailyBudgetCents"),
-				"warning_threshold_percent":     optionalInt64FromMap(slMap, "warningThresholdPercent"),
-				"interface_limits":              ilTF,
-				"user_overrides":                uoTF,
+				"monthly_budget_cents":           optionalInt64FromMap(slMap, "monthlyBudgetCents"),
+				"daily_budget_cents":             optionalInt64FromMap(slMap, "dailyBudgetCents"),
+				"per_user_monthly_budget_cents":  optionalInt64FromMap(slMap, "perUserMonthlyBudgetCents"),
+				"per_user_daily_budget_cents":    optionalInt64FromMap(slMap, "perUserDailyBudgetCents"),
+				"per_token_monthly_budget_cents": optionalInt64FromMap(slMap, "perTokenMonthlyBudgetCents"),
+				"per_token_daily_budget_cents":   optionalInt64FromMap(slMap, "perTokenDailyBudgetCents"),
+				"warning_threshold_percent":      optionalInt64FromMap(slMap, "warningThresholdPercent"),
+				"interface_limits":               ilTF,
+				"user_overrides":                 uoTF,
+				"token_overrides":                toTF,
 			}
 			slVal, d := resource_ai_governance.NewSpendLimitsValue(slAttrTypes, slAttrs)
 			diags.Append(d...)

--- a/internal/provider/ai_governance_spend_limits.go
+++ b/internal/provider/ai_governance_spend_limits.go
@@ -58,6 +58,31 @@ func userOverridesToSDK(ctx context.Context, m types.Map) (map[string]quantadmin
 	return out, diags
 }
 
+// tokenOverridesToSDK converts the Terraform token_overrides map into the SDK
+// map for a governance write. The SDK reuses the user-override value type for
+// token overrides (identical schema, deduplicated by the generator). The caller
+// guards against null/unknown.
+func tokenOverridesToSDK(ctx context.Context, m types.Map) (map[string]quantadmingo.GetGovernanceConfig200ResponseSpendLimitsUserOverridesValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elems := map[string]resource_ai_governance.TokenOverridesValue{}
+	diags.Append(m.ElementsAs(ctx, &elems, false)...)
+	out := make(map[string]quantadmingo.GetGovernanceConfig200ResponseSpendLimitsUserOverridesValue, len(elems))
+	for label, to := range elems {
+		v := quantadmingo.NewGetGovernanceConfig200ResponseSpendLimitsUserOverridesValue()
+		if !to.DailyCents.IsNull() && !to.DailyCents.IsUnknown() {
+			v.SetDailyCents(int32(to.DailyCents.ValueInt64()))
+		}
+		if !to.MonthlyCents.IsNull() && !to.MonthlyCents.IsUnknown() {
+			v.SetMonthlyCents(int32(to.MonthlyCents.ValueInt64()))
+		}
+		if !to.Unlimited.IsNull() && !to.Unlimited.IsUnknown() {
+			v.SetUnlimited(to.Unlimited.ValueBool())
+		}
+		out[label] = *v
+	}
+	return out, diags
+}
+
 // interfaceLimitsToTF builds the Terraform interface_limits map from the typed
 // SDK response (Read / ImportState path).
 func interfaceLimitsToTF(ctx context.Context, sdkMap map[string]quantadmingo.GetGovernanceConfig200ResponseSpendLimitsInterfaceLimitsValue) (types.Map, diag.Diagnostics) {
@@ -96,6 +121,30 @@ func userOverridesToTF(ctx context.Context, sdkMap map[string]quantadmingo.GetGo
 			"daily_cents":   nullableInt32ToInt64(uo.DailyCents),
 			"monthly_cents": nullableInt32ToInt64(uo.MonthlyCents),
 			"unlimited":     nullableBoolToBool(uo.Unlimited),
+		})
+		diags.Append(d...)
+		elems[label] = v
+	}
+	out, d := types.MapValue(elemType, elems)
+	diags.Append(d...)
+	return out, diags
+}
+
+// tokenOverridesToTF builds the Terraform token_overrides map from the typed
+// SDK response (Read / ImportState path).
+func tokenOverridesToTF(ctx context.Context, sdkMap map[string]quantadmingo.GetGovernanceConfig200ResponseSpendLimitsUserOverridesValue) (types.Map, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := resource_ai_governance.TokenOverridesValue{}.Type(ctx)
+	if len(sdkMap) == 0 {
+		return types.MapNull(elemType), diags
+	}
+	attrTypes := resource_ai_governance.TokenOverridesValue{}.AttributeTypes(ctx)
+	elems := make(map[string]attr.Value, len(sdkMap))
+	for label, to := range sdkMap {
+		v, d := resource_ai_governance.NewTokenOverridesValue(attrTypes, map[string]attr.Value{
+			"daily_cents":   nullableInt32ToInt64(to.DailyCents),
+			"monthly_cents": nullableInt32ToInt64(to.MonthlyCents),
+			"unlimited":     nullableBoolToBool(to.Unlimited),
 		})
 		diags.Append(d...)
 		elems[label] = v
@@ -144,6 +193,32 @@ func userOverridesFromRawMap(ctx context.Context, raw interface{}) (types.Map, d
 	for label, rv := range m {
 		entry, _ := rv.(map[string]interface{})
 		v, d := resource_ai_governance.NewUserOverridesValue(attrTypes, map[string]attr.Value{
+			"daily_cents":   optionalInt64FromMap(entry, "dailyCents"),
+			"monthly_cents": optionalInt64FromMap(entry, "monthlyCents"),
+			"unlimited":     optionalBoolFromMap(entry, "unlimited"),
+		})
+		diags.Append(d...)
+		elems[label] = v
+	}
+	out, d := types.MapValue(elemType, elems)
+	diags.Append(d...)
+	return out, diags
+}
+
+// tokenOverridesFromRawMap builds the Terraform token_overrides map from the
+// raw config map returned by the PUT (UpdateGovernanceConfig) response.
+func tokenOverridesFromRawMap(ctx context.Context, raw interface{}) (types.Map, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := resource_ai_governance.TokenOverridesValue{}.Type(ctx)
+	m, ok := raw.(map[string]interface{})
+	if !ok || len(m) == 0 {
+		return types.MapNull(elemType), diags
+	}
+	attrTypes := resource_ai_governance.TokenOverridesValue{}.AttributeTypes(ctx)
+	elems := make(map[string]attr.Value, len(m))
+	for label, rv := range m {
+		entry, _ := rv.(map[string]interface{})
+		v, d := resource_ai_governance.NewTokenOverridesValue(attrTypes, map[string]attr.Value{
 			"daily_cents":   optionalInt64FromMap(entry, "dailyCents"),
 			"monthly_cents": optionalInt64FromMap(entry, "monthlyCents"),
 			"unlimited":     optionalBoolFromMap(entry, "unlimited"),

--- a/internal/provider/ai_governance_spend_limits_test.go
+++ b/internal/provider/ai_governance_spend_limits_test.go
@@ -170,3 +170,95 @@ func TestSpendLimitsMapsNullWhenEmpty(t *testing.T) {
 		t.Fatalf("interfaceLimitsFromRawMap(nil): %v", diags)
 	}
 }
+
+// TestTokenOverridesRoundTrip covers the typed SDK ↔ Terraform conversion for
+// token_overrides (API v4.20.0). The SDK reuses the user-override value type.
+func TestTokenOverridesRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	sdkIn := map[string]quantadmingo.GetGovernanceConfig200ResponseSpendLimitsUserOverridesValue{}
+	capped := quantadmingo.NewGetGovernanceConfig200ResponseSpendLimitsUserOverridesValue()
+	capped.SetDailyCents(500)
+	capped.SetMonthlyCents(50000)
+	sdkIn["42"] = *capped
+	unlimited := quantadmingo.NewGetGovernanceConfig200ResponseSpendLimitsUserOverridesValue()
+	unlimited.SetUnlimited(true)
+	sdkIn["legacy-shared"] = *unlimited
+
+	tfMap, diags := tokenOverridesToTF(ctx, sdkIn)
+	if diags.HasError() {
+		t.Fatalf("tokenOverridesToTF: %v", diags)
+	}
+	if len(tfMap.Elements()) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(tfMap.Elements()))
+	}
+
+	sdkOut, diags := tokenOverridesToSDK(ctx, tfMap)
+	if diags.HasError() {
+		t.Fatalf("tokenOverridesToSDK: %v", diags)
+	}
+	cappedOut := sdkOut["42"]
+	if got := cappedOut.GetDailyCents(); got != 500 {
+		t.Errorf("token 42 daily_cents: want 500, got %d", got)
+	}
+	if got := cappedOut.GetMonthlyCents(); got != 50000 {
+		t.Errorf("token 42 monthly_cents: want 50000, got %d", got)
+	}
+	unlimitedOut := sdkOut["legacy-shared"]
+	if !unlimitedOut.GetUnlimited() {
+		t.Error("token legacy-shared unlimited: want true")
+	}
+	if _, ok := unlimitedOut.GetMonthlyCentsOk(); ok {
+		t.Error("token legacy-shared monthly_cents should remain unset")
+	}
+}
+
+// TestTokenOverridesFromRawMap covers the PUT-response path for token
+// overrides, including the unlimited bool and JSON-number (float64) cents.
+func TestTokenOverridesFromRawMap(t *testing.T) {
+	ctx := context.Background()
+	raw := map[string]interface{}{
+		"42": map[string]interface{}{
+			"monthlyCents": float64(50000),
+		},
+		"legacy-shared": map[string]interface{}{
+			"unlimited": true,
+		},
+	}
+	tfMap, diags := tokenOverridesFromRawMap(ctx, raw)
+	if diags.HasError() {
+		t.Fatalf("tokenOverridesFromRawMap: %v", diags)
+	}
+	sdkOut, diags := tokenOverridesToSDK(ctx, tfMap)
+	if diags.HasError() {
+		t.Fatalf("tokenOverridesToSDK: %v", diags)
+	}
+	cappedOut := sdkOut["42"]
+	if got := cappedOut.GetMonthlyCents(); got != 50000 {
+		t.Errorf("token 42 monthly_cents: want 50000, got %d", got)
+	}
+	unlimitedOut := sdkOut["legacy-shared"]
+	if !unlimitedOut.GetUnlimited() {
+		t.Error("token legacy-shared unlimited: want true")
+	}
+}
+
+// TestTokenOverridesNullWhenEmpty ensures empty/absent token_overrides map to
+// a null Terraform map (not an empty one), so plans stay stable.
+func TestTokenOverridesNullWhenEmpty(t *testing.T) {
+	ctx := context.Background()
+	to, diags := tokenOverridesToTF(ctx, nil)
+	if diags.HasError() {
+		t.Fatalf("tokenOverridesToTF(nil): %v", diags)
+	}
+	if !to.IsNull() {
+		t.Error("expected null token_overrides for empty input")
+	}
+	toRaw, diags := tokenOverridesFromRawMap(ctx, nil)
+	if diags.HasError() {
+		t.Fatalf("tokenOverridesFromRawMap(nil): %v", diags)
+	}
+	if !toRaw.IsNull() {
+		t.Error("expected null token_overrides for nil raw input")
+	}
+}

--- a/internal/provider/environment_resource.go
+++ b/internal/provider/environment_resource.go
@@ -478,6 +478,16 @@ func callEnvironmentReadAPI(ctx context.Context, r *environmentResource, data *r
 	data.TaskDefinition = resource_environment.NewTaskDefinitionValueNull()
 	data.Vpc = resource_environment.NewVpcValueNull()
 
+	// --- v4.20.0 task-mode fields: preserve if known, null out unknowns ---
+	// The EnvironmentResponse SDK model does not surface these yet; the
+	// platform auto-detects when omitted.
+	if data.SingleTaskOnly.IsUnknown() {
+		data.SingleTaskOnly = types.BoolNull()
+	}
+	if data.StartupGracePeriodSeconds.IsUnknown() {
+		data.StartupGracePeriodSeconds = types.Int64Null()
+	}
+
 	// --- Create-only scalars: preserve if known, null out unknowns ---
 	if data.CloneConfigurationFrom.IsUnknown() {
 		data.CloneConfigurationFrom = types.StringNull()

--- a/pulumi/e2e/programs/ai/Pulumi.yaml
+++ b/pulumi/e2e/programs/ai/Pulumi.yaml
@@ -32,6 +32,12 @@ resources:
         userOverrides:
           "system:code-agent":
             unlimited: true
+        perTokenMonthlyBudgetCents: 50000
+        tokenOverrides:
+          "e2e-test-token":
+            monthlyCents: 200000
+          "e2e-unlimited-token":
+            unlimited: true
   testSkill:
     type: quant:index:AiSkill
     properties:

--- a/pulumi/go.mod
+++ b/pulumi/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.116.0
 	github.com/pulumi/pulumi/sdk/v3 v3.190.0
-	github.com/quantcdn/quant-admin-go/v4 v4.19.0
+	github.com/quantcdn/quant-admin-go/v4 v4.20.0
 	github.com/quantcdn/terraform-provider-quant/v5 v5.0.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/pulumi/go.sum
+++ b/pulumi/go.sum
@@ -757,8 +757,8 @@ github.com/pulumi/terraform-diff-reader v0.0.2 h1:kTE4nEXU3/SYXESvAIem+wyHMI3abq
 github.com/pulumi/terraform-diff-reader v0.0.2/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250923233607-7f1981c8674a h1:bTwou+tt2fyfuuCp9+VQOlgEJk/xKEaYeoX2HCtp2es=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250923233607-7f1981c8674a/go.mod h1:rpW/bFN645nI+o0jth9hyIs/eWi3GP3B1J39fWZKC0Y=
-github.com/quantcdn/quant-admin-go/v4 v4.19.0 h1:KShkFOCb7zMHBWzHtetroGkJ+RLfEHK1NJJkex64NRI=
-github.com/quantcdn/quant-admin-go/v4 v4.19.0/go.mod h1:IHW0nqZIs1meRihtfkKedVrmjl8iuKqVxM9i9lExoAw=
+github.com/quantcdn/quant-admin-go/v4 v4.20.0 h1:oNdXojSVm1jvAwvTB5fcnoBbCU+JRVtdlvsw0Vl0HZI=
+github.com/quantcdn/quant-admin-go/v4 v4.20.0/go.mod h1:IHW0nqZIs1meRihtfkKedVrmjl8iuKqVxM9i9lExoAw=
 github.com/rhysd/go-fakeio v1.0.0 h1:+TjiKCOs32dONY7DaoVz/VPOdvRkPfBkEyUDIpM8FQY=
 github.com/rhysd/go-fakeio v1.0.0/go.mod h1:joYxF906trVwp2JLrE4jlN7A0z6wrz8O6o1UjarbFzE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pulumi/provider/cmd/pulumi-resource-quant/schema.json
+++ b/pulumi/provider/cmd/pulumi-resource-quant/schema.json
@@ -382,11 +382,26 @@
                 "monthlyBudgetCents": {
                     "type": "integer"
                 },
+                "perTokenDailyBudgetCents": {
+                    "type": "integer",
+                    "description": "Flat daily cap in cents applied to every API token without a named override\n"
+                },
+                "perTokenMonthlyBudgetCents": {
+                    "type": "integer",
+                    "description": "Flat monthly cap in cents applied to every API token without a named override\n"
+                },
                 "perUserDailyBudgetCents": {
                     "type": "integer"
                 },
                 "perUserMonthlyBudgetCents": {
                     "type": "integer"
+                },
+                "tokenOverrides": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/types/quant:index/AiGovernanceSpendLimitsTokenOverrides:AiGovernanceSpendLimitsTokenOverrides"
+                    },
+                    "description": "Per-token budget overrides keyed by API token id. Replaces the flat per-token budget for that token; unlimited=true exempts it.\n"
                 },
                 "userOverrides": {
                     "type": "object",
@@ -406,8 +421,11 @@
                         "dailyBudgetCents",
                         "interfaceLimits",
                         "monthlyBudgetCents",
+                        "perTokenDailyBudgetCents",
+                        "perTokenMonthlyBudgetCents",
                         "perUserDailyBudgetCents",
                         "perUserMonthlyBudgetCents",
+                        "tokenOverrides",
                         "userOverrides",
                         "warningThresholdPercent"
                     ]
@@ -429,6 +447,29 @@
                     "requiredOutputs": [
                         "dailyCents",
                         "monthlyCents"
+                    ]
+                }
+            }
+        },
+        "quant:index/AiGovernanceSpendLimitsTokenOverrides:AiGovernanceSpendLimitsTokenOverrides": {
+            "properties": {
+                "dailyCents": {
+                    "type": "integer"
+                },
+                "monthlyCents": {
+                    "type": "integer"
+                },
+                "unlimited": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object",
+            "language": {
+                "nodejs": {
+                    "requiredOutputs": [
+                        "dailyCents",
+                        "monthlyCents",
+                        "unlimited"
                     ]
                 }
             }
@@ -642,6 +683,32 @@
                 }
             }
         },
+        "quant:index/ApplicationCache:ApplicationCache": {
+            "properties": {
+                "cacheEndpoint": {
+                    "type": "string",
+                    "description": "Cache cluster endpoint\n"
+                },
+                "cacheIdentifier": {
+                    "type": "string",
+                    "description": "Cache cluster identifier\n"
+                },
+                "dataStorageMaxGb": {
+                    "type": "integer",
+                    "description": "Maximum cache storage in GB\n"
+                }
+            },
+            "type": "object",
+            "language": {
+                "nodejs": {
+                    "requiredOutputs": [
+                        "cacheEndpoint",
+                        "cacheIdentifier",
+                        "dataStorageMaxGb"
+                    ]
+                }
+            }
+        },
         "quant:index/ApplicationComposeDefinition:ApplicationComposeDefinition": {
             "properties": {
                 "architecture": {
@@ -670,9 +737,17 @@
                     "type": "integer",
                     "description": "Minimum number of instances\n"
                 },
+                "singleTaskOnly": {
+                    "type": "boolean",
+                    "description": "Optional. Forces single-task mode for data-safe applications (max one running task). When true: capacity is locked to 1. When false: explicitly allows scaling. When omitted: the platform auto-detects stateful containers and enables single-task mode if found.\n"
+                },
                 "spotConfiguration": {
                     "$ref": "#/types/quant:index/ApplicationComposeDefinitionSpotConfiguration:ApplicationComposeDefinitionSpotConfiguration",
                     "description": "Spot instance strategy configuration for controlling cost vs reliability. Spot instances provide significant cost savings (~70%) but may be interrupted by AWS. Available for non-production environments.\n"
+                },
+                "startupGracePeriodSeconds": {
+                    "type": "integer",
+                    "description": "Optional. Seconds the load balancer waits after a task starts before an unhealthy health check can replace it (applied as the ECS service's healthCheckGracePeriodSeconds when a load balancer is attached). Raise for apps that are slow to boot, e.g. run migrations on startup. Tasks that become healthy sooner still enter service immediately. Defaults to 120 when omitted.\n"
                 },
                 "taskCpu": {
                     "type": "integer",
@@ -693,7 +768,9 @@
                         "enableCrossEnvNetworking",
                         "maxCapacity",
                         "minCapacity",
+                        "singleTaskOnly",
                         "spotConfiguration",
+                        "startupGracePeriodSeconds",
                         "taskCpu",
                         "taskMemory"
                     ]
@@ -1338,9 +1415,17 @@
                     "type": "integer",
                     "description": "Minimum number of instances\n"
                 },
+                "singleTaskOnly": {
+                    "type": "boolean",
+                    "description": "Optional. Forces single-task mode for data-safe applications (max one running task). When true: capacity is locked to 1. When false: explicitly allows scaling. When omitted: the platform auto-detects stateful containers and enables single-task mode if found.\n"
+                },
                 "spotConfiguration": {
                     "$ref": "#/types/quant:index/EnvironmentComposeDefinitionSpotConfiguration:EnvironmentComposeDefinitionSpotConfiguration",
                     "description": "Spot instance strategy configuration for controlling cost vs reliability. Spot instances provide significant cost savings (~70%) but may be interrupted by AWS. Available for non-production environments.\n"
+                },
+                "startupGracePeriodSeconds": {
+                    "type": "integer",
+                    "description": "Optional. Seconds the load balancer waits after a task starts before an unhealthy health check can replace it (applied as the ECS service's healthCheckGracePeriodSeconds when a load balancer is attached). Raise for apps that are slow to boot, e.g. run migrations on startup. Tasks that become healthy sooner still enter service immediately. Defaults to 120 when omitted.\n"
                 },
                 "taskCpu": {
                     "type": "integer",
@@ -1361,7 +1446,9 @@
                         "enableCrossEnvNetworking",
                         "maxCapacity",
                         "minCapacity",
+                        "singleTaskOnly",
                         "spotConfiguration",
+                        "startupGracePeriodSeconds",
                         "taskCpu",
                         "taskMemory"
                     ]
@@ -4206,6 +4293,10 @@
                     "type": "string",
                     "description": "The application ID"
                 },
+                "cache": {
+                    "$ref": "#/types/quant:index/ApplicationCache:ApplicationCache",
+                    "description": "Managed Valkey cache configuration"
+                },
                 "composeDefinition": {
                     "$ref": "#/types/quant:index/ApplicationComposeDefinition:ApplicationComposeDefinition"
                 },
@@ -4277,6 +4368,7 @@
             "required": [
                 "appName",
                 "application",
+                "cache",
                 "composeDefinition",
                 "containerNames",
                 "database",
@@ -4342,6 +4434,10 @@
                     "application": {
                         "type": "string",
                         "description": "The application ID"
+                    },
+                    "cache": {
+                        "$ref": "#/types/quant:index/ApplicationCache:ApplicationCache",
+                        "description": "Managed Valkey cache configuration"
                     },
                     "composeDefinition": {
                         "$ref": "#/types/quant:index/ApplicationComposeDefinition:ApplicationComposeDefinition"
@@ -5385,9 +5481,17 @@
                     "$ref": "#/types/quant:index/EnvironmentService:EnvironmentService",
                     "description": "ECS service details"
                 },
+                "singleTaskOnly": {
+                    "type": "boolean",
+                    "description": "Optional. Forces single-task mode (max one running task). When omitted, the platform auto-detects stateful containers."
+                },
                 "spotConfiguration": {
                     "$ref": "#/types/quant:index/EnvironmentSpotConfiguration:EnvironmentSpotConfiguration",
                     "description": "Spot instance strategy configuration for controlling cost vs reliability. Spot instances provide significant cost savings (~70%) but may be interrupted by AWS. Available for non-production environments."
+                },
+                "startupGracePeriodSeconds": {
+                    "type": "integer",
+                    "description": "Optional. Seconds the load balancer waits after a task starts before an unhealthy health check can replace it. If not set, the value from composeDefinition (or default 120) is used."
                 },
                 "status": {
                     "type": "string",
@@ -5441,7 +5545,9 @@
                 "runningCount",
                 "securityGroup",
                 "service",
+                "singleTaskOnly",
                 "spotConfiguration",
+                "startupGracePeriodSeconds",
                 "status",
                 "subnet",
                 "taskDefinition",
@@ -5492,9 +5598,17 @@
                     "type": "string",
                     "description": "The organisation ID"
                 },
+                "singleTaskOnly": {
+                    "type": "boolean",
+                    "description": "Optional. Forces single-task mode (max one running task). When omitted, the platform auto-detects stateful containers."
+                },
                 "spotConfiguration": {
                     "$ref": "#/types/quant:index/EnvironmentSpotConfiguration:EnvironmentSpotConfiguration",
                     "description": "Spot instance strategy configuration for controlling cost vs reliability. Spot instances provide significant cost savings (~70%) but may be interrupted by AWS. Available for non-production environments."
+                },
+                "startupGracePeriodSeconds": {
+                    "type": "integer",
+                    "description": "Optional. Seconds the load balancer waits after a task starts before an unhealthy health check can replace it. If not set, the value from composeDefinition (or default 120) is used."
                 }
             },
             "requiredInputs": [
@@ -5603,9 +5717,17 @@
                         "$ref": "#/types/quant:index/EnvironmentService:EnvironmentService",
                         "description": "ECS service details"
                     },
+                    "singleTaskOnly": {
+                        "type": "boolean",
+                        "description": "Optional. Forces single-task mode (max one running task). When omitted, the platform auto-detects stateful containers."
+                    },
                     "spotConfiguration": {
                         "$ref": "#/types/quant:index/EnvironmentSpotConfiguration:EnvironmentSpotConfiguration",
                         "description": "Spot instance strategy configuration for controlling cost vs reliability. Spot instances provide significant cost savings (~70%) but may be interrupted by AWS. Available for non-production environments."
+                    },
+                    "startupGracePeriodSeconds": {
+                        "type": "integer",
+                        "description": "Optional. Seconds the load balancer waits after a task starts before an unhealthy health check can replace it. If not set, the value from composeDefinition (or default 120) is used."
                     },
                     "status": {
                         "type": "string",

--- a/pulumi/provider/provider_test.go
+++ b/pulumi/provider/provider_test.go
@@ -353,8 +353,9 @@ resources:
 }
 
 // Exercises the v4.19.0 governance spend-limit maps end-to-end through the
-// Pulumi schema + bridge: interface_limits (per-interface caps) and
-// user_overrides (named per-user caps incl. unlimited).
+// Pulumi schema + bridge: interface_limits (per-interface caps),
+// user_overrides (named per-user caps incl. unlimited), and the v4.20.0
+// per-token budgets + token_overrides (named per-token caps incl. unlimited).
 func TestPreview_AiGovernanceSpendLimits(t *testing.T) {
 	previewProgram(t, "test-ai-governance", `
 name: test-ai-governance
@@ -368,6 +369,8 @@ resources:
       modelPolicy: blocklist
       spendLimits:
         monthlyBudgetCents: 1000000
+        perTokenMonthlyBudgetCents: 50000
+        perTokenDailyBudgetCents: 5000
         interfaceLimits:
           slack:
             dailyCents: 5000
@@ -379,6 +382,11 @@ resources:
             dailyCents: 20000
             monthlyCents: 400000
           "5678":
+            unlimited: true
+        tokenOverrides:
+          "42":
+            monthlyCents: 200000
+          "legacy-shared":
             unlimited: true
 `)
 }

--- a/pulumi/schema/schema.json
+++ b/pulumi/schema/schema.json
@@ -382,11 +382,26 @@
                 "monthlyBudgetCents": {
                     "type": "integer"
                 },
+                "perTokenDailyBudgetCents": {
+                    "type": "integer",
+                    "description": "Flat daily cap in cents applied to every API token without a named override\n"
+                },
+                "perTokenMonthlyBudgetCents": {
+                    "type": "integer",
+                    "description": "Flat monthly cap in cents applied to every API token without a named override\n"
+                },
                 "perUserDailyBudgetCents": {
                     "type": "integer"
                 },
                 "perUserMonthlyBudgetCents": {
                     "type": "integer"
+                },
+                "tokenOverrides": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/types/quant:index/AiGovernanceSpendLimitsTokenOverrides:AiGovernanceSpendLimitsTokenOverrides"
+                    },
+                    "description": "Per-token budget overrides keyed by API token id. Replaces the flat per-token budget for that token; unlimited=true exempts it.\n"
                 },
                 "userOverrides": {
                     "type": "object",
@@ -406,8 +421,11 @@
                         "dailyBudgetCents",
                         "interfaceLimits",
                         "monthlyBudgetCents",
+                        "perTokenDailyBudgetCents",
+                        "perTokenMonthlyBudgetCents",
                         "perUserDailyBudgetCents",
                         "perUserMonthlyBudgetCents",
+                        "tokenOverrides",
                         "userOverrides",
                         "warningThresholdPercent"
                     ]
@@ -429,6 +447,29 @@
                     "requiredOutputs": [
                         "dailyCents",
                         "monthlyCents"
+                    ]
+                }
+            }
+        },
+        "quant:index/AiGovernanceSpendLimitsTokenOverrides:AiGovernanceSpendLimitsTokenOverrides": {
+            "properties": {
+                "dailyCents": {
+                    "type": "integer"
+                },
+                "monthlyCents": {
+                    "type": "integer"
+                },
+                "unlimited": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object",
+            "language": {
+                "nodejs": {
+                    "requiredOutputs": [
+                        "dailyCents",
+                        "monthlyCents",
+                        "unlimited"
                     ]
                 }
             }
@@ -642,6 +683,32 @@
                 }
             }
         },
+        "quant:index/ApplicationCache:ApplicationCache": {
+            "properties": {
+                "cacheEndpoint": {
+                    "type": "string",
+                    "description": "Cache cluster endpoint\n"
+                },
+                "cacheIdentifier": {
+                    "type": "string",
+                    "description": "Cache cluster identifier\n"
+                },
+                "dataStorageMaxGb": {
+                    "type": "integer",
+                    "description": "Maximum cache storage in GB\n"
+                }
+            },
+            "type": "object",
+            "language": {
+                "nodejs": {
+                    "requiredOutputs": [
+                        "cacheEndpoint",
+                        "cacheIdentifier",
+                        "dataStorageMaxGb"
+                    ]
+                }
+            }
+        },
         "quant:index/ApplicationComposeDefinition:ApplicationComposeDefinition": {
             "properties": {
                 "architecture": {
@@ -670,9 +737,17 @@
                     "type": "integer",
                     "description": "Minimum number of instances\n"
                 },
+                "singleTaskOnly": {
+                    "type": "boolean",
+                    "description": "Optional. Forces single-task mode for data-safe applications (max one running task). When true: capacity is locked to 1. When false: explicitly allows scaling. When omitted: the platform auto-detects stateful containers and enables single-task mode if found.\n"
+                },
                 "spotConfiguration": {
                     "$ref": "#/types/quant:index/ApplicationComposeDefinitionSpotConfiguration:ApplicationComposeDefinitionSpotConfiguration",
                     "description": "Spot instance strategy configuration for controlling cost vs reliability. Spot instances provide significant cost savings (~70%) but may be interrupted by AWS. Available for non-production environments.\n"
+                },
+                "startupGracePeriodSeconds": {
+                    "type": "integer",
+                    "description": "Optional. Seconds the load balancer waits after a task starts before an unhealthy health check can replace it (applied as the ECS service's healthCheckGracePeriodSeconds when a load balancer is attached). Raise for apps that are slow to boot, e.g. run migrations on startup. Tasks that become healthy sooner still enter service immediately. Defaults to 120 when omitted.\n"
                 },
                 "taskCpu": {
                     "type": "integer",
@@ -693,7 +768,9 @@
                         "enableCrossEnvNetworking",
                         "maxCapacity",
                         "minCapacity",
+                        "singleTaskOnly",
                         "spotConfiguration",
+                        "startupGracePeriodSeconds",
                         "taskCpu",
                         "taskMemory"
                     ]
@@ -1338,9 +1415,17 @@
                     "type": "integer",
                     "description": "Minimum number of instances\n"
                 },
+                "singleTaskOnly": {
+                    "type": "boolean",
+                    "description": "Optional. Forces single-task mode for data-safe applications (max one running task). When true: capacity is locked to 1. When false: explicitly allows scaling. When omitted: the platform auto-detects stateful containers and enables single-task mode if found.\n"
+                },
                 "spotConfiguration": {
                     "$ref": "#/types/quant:index/EnvironmentComposeDefinitionSpotConfiguration:EnvironmentComposeDefinitionSpotConfiguration",
                     "description": "Spot instance strategy configuration for controlling cost vs reliability. Spot instances provide significant cost savings (~70%) but may be interrupted by AWS. Available for non-production environments.\n"
+                },
+                "startupGracePeriodSeconds": {
+                    "type": "integer",
+                    "description": "Optional. Seconds the load balancer waits after a task starts before an unhealthy health check can replace it (applied as the ECS service's healthCheckGracePeriodSeconds when a load balancer is attached). Raise for apps that are slow to boot, e.g. run migrations on startup. Tasks that become healthy sooner still enter service immediately. Defaults to 120 when omitted.\n"
                 },
                 "taskCpu": {
                     "type": "integer",
@@ -1361,7 +1446,9 @@
                         "enableCrossEnvNetworking",
                         "maxCapacity",
                         "minCapacity",
+                        "singleTaskOnly",
                         "spotConfiguration",
+                        "startupGracePeriodSeconds",
                         "taskCpu",
                         "taskMemory"
                     ]
@@ -4206,6 +4293,10 @@
                     "type": "string",
                     "description": "The application ID"
                 },
+                "cache": {
+                    "$ref": "#/types/quant:index/ApplicationCache:ApplicationCache",
+                    "description": "Managed Valkey cache configuration"
+                },
                 "composeDefinition": {
                     "$ref": "#/types/quant:index/ApplicationComposeDefinition:ApplicationComposeDefinition"
                 },
@@ -4277,6 +4368,7 @@
             "required": [
                 "appName",
                 "application",
+                "cache",
                 "composeDefinition",
                 "containerNames",
                 "database",
@@ -4342,6 +4434,10 @@
                     "application": {
                         "type": "string",
                         "description": "The application ID"
+                    },
+                    "cache": {
+                        "$ref": "#/types/quant:index/ApplicationCache:ApplicationCache",
+                        "description": "Managed Valkey cache configuration"
                     },
                     "composeDefinition": {
                         "$ref": "#/types/quant:index/ApplicationComposeDefinition:ApplicationComposeDefinition"
@@ -5385,9 +5481,17 @@
                     "$ref": "#/types/quant:index/EnvironmentService:EnvironmentService",
                     "description": "ECS service details"
                 },
+                "singleTaskOnly": {
+                    "type": "boolean",
+                    "description": "Optional. Forces single-task mode (max one running task). When omitted, the platform auto-detects stateful containers."
+                },
                 "spotConfiguration": {
                     "$ref": "#/types/quant:index/EnvironmentSpotConfiguration:EnvironmentSpotConfiguration",
                     "description": "Spot instance strategy configuration for controlling cost vs reliability. Spot instances provide significant cost savings (~70%) but may be interrupted by AWS. Available for non-production environments."
+                },
+                "startupGracePeriodSeconds": {
+                    "type": "integer",
+                    "description": "Optional. Seconds the load balancer waits after a task starts before an unhealthy health check can replace it. If not set, the value from composeDefinition (or default 120) is used."
                 },
                 "status": {
                     "type": "string",
@@ -5441,7 +5545,9 @@
                 "runningCount",
                 "securityGroup",
                 "service",
+                "singleTaskOnly",
                 "spotConfiguration",
+                "startupGracePeriodSeconds",
                 "status",
                 "subnet",
                 "taskDefinition",
@@ -5492,9 +5598,17 @@
                     "type": "string",
                     "description": "The organisation ID"
                 },
+                "singleTaskOnly": {
+                    "type": "boolean",
+                    "description": "Optional. Forces single-task mode (max one running task). When omitted, the platform auto-detects stateful containers."
+                },
                 "spotConfiguration": {
                     "$ref": "#/types/quant:index/EnvironmentSpotConfiguration:EnvironmentSpotConfiguration",
                     "description": "Spot instance strategy configuration for controlling cost vs reliability. Spot instances provide significant cost savings (~70%) but may be interrupted by AWS. Available for non-production environments."
+                },
+                "startupGracePeriodSeconds": {
+                    "type": "integer",
+                    "description": "Optional. Seconds the load balancer waits after a task starts before an unhealthy health check can replace it. If not set, the value from composeDefinition (or default 120) is used."
                 }
             },
             "requiredInputs": [
@@ -5603,9 +5717,17 @@
                         "$ref": "#/types/quant:index/EnvironmentService:EnvironmentService",
                         "description": "ECS service details"
                     },
+                    "singleTaskOnly": {
+                        "type": "boolean",
+                        "description": "Optional. Forces single-task mode (max one running task). When omitted, the platform auto-detects stateful containers."
+                    },
                     "spotConfiguration": {
                         "$ref": "#/types/quant:index/EnvironmentSpotConfiguration:EnvironmentSpotConfiguration",
                         "description": "Spot instance strategy configuration for controlling cost vs reliability. Spot instances provide significant cost savings (~70%) but may be interrupted by AWS. Available for non-production environments."
+                    },
+                    "startupGracePeriodSeconds": {
+                        "type": "integer",
+                        "description": "Optional. Seconds the load balancer waits after a task starts before an unhealthy health check can replace it. If not set, the value from composeDefinition (or default 120) is used."
                     },
                     "status": {
                         "type": "string",


### PR DESCRIPTION
Completes the v4.20.0 chain (portal#644 → quant-admin-go#25 → #155 → this): the generated schemas landed in #155, this adds the hand-written layer.

## Changes
- **SDK bump**: `quant-admin-go` v4.19.0 → v4.20.0 in both `go.mod`s
- **Per-token spend limit mappings**: `tokenOverridesToSDK`/`ToTF`/`FromRawMap` converters mirroring the user-override trio (SDK reuses the user-override value type — identical schema, deduplicated by the generator); `per_token_monthly/daily_budget_cents` scalars wired through the write, typed-read, and raw-PUT-response paths
- **Environment fix (release blocker found en route)**: #155's regen added `single_task_only`/`startup_grace_period_seconds` with no CRUD handling — computed attributes stayed unknown after apply and failed framework result validation (`TestAccEnvironmentResource` was red on main). Now preserved-if-known/nulled-if-unknown per the file's pattern
- **Pulumi**: bridge schema regenerated for v4.20.0; preview test + e2e ai program extended with per-token budgets and token overrides (incl. `unlimited`)

## Testing
- `TF_ACC=1 go test ./internal/provider/` — all green (incl. previously-failing `TestAccEnvironmentResource`)
- `cd pulumi && go test ./provider/` — all green
- New unit coverage: token-override round-trip, raw-map path, null-when-empty plan stability

After merge: tag `v5.12.0` → release workflow publishes TF binaries, Pulumi binaries (5 platforms), and `@quantcdn/pulumi-quant` to npm.